### PR TITLE
Use native composer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ services:
   - docker
 
 install:
-  - travis_retry make composer install
+  - travis_retry composer install --prefer-dist --no-interaction --ignore-platform-reqs
 
 script:
-  - composer validate --no-interaction
   - make ci
 
 after_success:


### PR DESCRIPTION
There were some GitHub errors for the payment dependency, so for now
we're using the native composer install on Travis.