### PR TITLE
Improve payment data validation

### DIFF
--- a/src/UseCases/ApplyForMembership/ApplicationValidationResult.php
+++ b/src/UseCases/ApplyForMembership/ApplicationValidationResult.php
@@ -11,11 +11,6 @@ namespace WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership;
 class ApplicationValidationResult {
 
 	const SOURCE_PAYMENT_AMOUNT = 'amount';
-	const SOURCE_IBAN = 'iban';
-	const SOURCE_BIC = 'bic';
-	const SOURCE_BANK_NAME = 'bank-name';
-	const SOURCE_BANK_CODE = 'bank-code';
-	const SOURCE_BANK_ACCOUNT = 'bank-account';
 	const SOURCE_APPLICANT_DATE_OF_BIRTH = 'applicant-dob';
 	const SOURCE_APPLICANT_PHONE_NUMBER = 'applicant-phone';
 	const SOURCE_APPLICANT_EMAIL = 'applicant-email';
@@ -33,7 +28,6 @@ class ApplicationValidationResult {
 	const VIOLATION_NOT_MONEY = 'not-money';
 	const VIOLATION_MISSING = 'missing';
 	const VIOLATION_IBAN_BLOCKED = 'iban-blocked';
-	const VIOLATION_IBAN_INVALID = 'iban-invalid';
 	const VIOLATION_NOT_DATE = 'not-date';
 	const VIOLATION_NOT_PHONE_NUMBER = 'not-phone';
 	const VIOLATION_NOT_EMAIL = 'not-email';


### PR DESCRIPTION
Use "native" validation identifiers from payment domain.
Re-introduce validation of blocked iban which were removed from
IbanValidator in https://github.com/wmde/fundraising-payments/pull/7

This is for https://phabricator.wikimedia.org/T192921