### PR TITLE
Fix architecture violation

### DIFF
--- a/src/UseCases/ApplyForMembership/ApplicationValidationResult.php
+++ b/src/UseCases/ApplyForMembership/ApplicationValidationResult.php
@@ -10,27 +10,27 @@ namespace WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership;
  */
 class ApplicationValidationResult {
 
-	const SOURCE_PAYMENT_AMOUNT = 'amount';
-	const SOURCE_APPLICANT_DATE_OF_BIRTH = 'applicant-dob';
-	const SOURCE_APPLICANT_PHONE_NUMBER = 'applicant-phone';
-	const SOURCE_APPLICANT_EMAIL = 'applicant-email';
-	const SOURCE_APPLICANT_COMPANY = 'company';
-	const SOURCE_APPLICANT_FIRST_NAME = 'applicant-first-name';
-	const SOURCE_APPLICANT_LAST_NAME = 'applicant-last-name';
-	const SOURCE_APPLICANT_SALUTATION = 'applicant-salutation';
-	const SOURCE_APPLICANT_STREET_ADDRESS = 'street-address';
-	const SOURCE_APPLICANT_POSTAL_CODE = 'postal-code';
-	const SOURCE_APPLICANT_CITY = 'city';
-	const SOURCE_APPLICANT_COUNTRY = 'country-code';
+	public const SOURCE_PAYMENT_AMOUNT = 'amount';
+	public const SOURCE_APPLICANT_DATE_OF_BIRTH = 'applicant-dob';
+	public const SOURCE_APPLICANT_PHONE_NUMBER = 'applicant-phone';
+	public const SOURCE_APPLICANT_EMAIL = 'applicant-email';
+	public const SOURCE_APPLICANT_COMPANY = 'company';
+	public const SOURCE_APPLICANT_FIRST_NAME = 'applicant-first-name';
+	public const SOURCE_APPLICANT_LAST_NAME = 'applicant-last-name';
+	public const SOURCE_APPLICANT_SALUTATION = 'applicant-salutation';
+	public const SOURCE_APPLICANT_STREET_ADDRESS = 'street-address';
+	public const SOURCE_APPLICANT_POSTAL_CODE = 'postal-code';
+	public const SOURCE_APPLICANT_CITY = 'city';
+	public const SOURCE_APPLICANT_COUNTRY = 'country-code';
 
-	const VIOLATION_TOO_LOW = 'too-low';
-	const VIOLATION_WRONG_LENGTH = 'wrong-length';
-	const VIOLATION_NOT_MONEY = 'not-money';
-	const VIOLATION_MISSING = 'missing';
-	const VIOLATION_IBAN_BLOCKED = 'iban-blocked';
-	const VIOLATION_NOT_DATE = 'not-date';
-	const VIOLATION_NOT_PHONE_NUMBER = 'not-phone';
-	const VIOLATION_NOT_EMAIL = 'not-email';
+	public const VIOLATION_TOO_LOW = 'too-low';
+	public const VIOLATION_WRONG_LENGTH = 'wrong-length';
+	public const VIOLATION_NOT_MONEY = 'not-money';
+	public const VIOLATION_MISSING = 'missing';
+	public const VIOLATION_IBAN_BLOCKED = 'iban-blocked';
+	public const VIOLATION_NOT_DATE = 'not-date';
+	public const VIOLATION_NOT_PHONE_NUMBER = 'not-phone';
+	public const VIOLATION_NOT_EMAIL = 'not-email';
 
 	private $violations;
 

--- a/src/UseCases/ApplyForMembership/ApplyForMembershipRequest.php
+++ b/src/UseCases/ApplyForMembership/ApplyForMembershipRequest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership;
 
+use WMDE\Euro\Euro;
 use WMDE\FreezableValueObject\FreezableValueObject;
 use WMDE\Fundraising\MembershipContext\Tracking\MembershipApplicationTrackingInfo;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
@@ -180,11 +181,11 @@ class ApplyForMembershipRequest {
 		$this->paymentIntervalInMonths = $paymentIntervalInMonths;
 	}
 
-	public function getPaymentAmountInEuros(): string {
+	public function getPaymentAmountInEuros(): Euro {
 		return $this->paymentAmount;
 	}
 
-	public function setPaymentAmountInEuros( string $paymentAmount ): void {
+	public function setPaymentAmountInEuros( Euro $paymentAmount ): void {
 		$this->assertIsWritable();
 		$this->paymentAmount = $paymentAmount;
 	}

--- a/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
@@ -81,7 +81,7 @@ class MembershipApplicationBuilder {
 	private function newPayment( ApplyForMembershipRequest $request ): Payment {
 		return new Payment(
 			$request->getPaymentIntervalInMonths(),
-			Euro::newFromString( $request->getPaymentAmountInEuros() ),
+			$request->getPaymentAmountInEuros(),
 			$this->newPaymentMethod( $request )
 		);
 	}

--- a/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership;
 
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
+use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidationResult;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidator;
 use WMDE\Fundraising\PaymentContext\Domain\IbanBlocklist;
@@ -45,7 +46,7 @@ class MembershipApplicationValidator {
 		Result::SOURCE_APPLICANT_COUNTRY => 8,
 	];
 
-	public function __construct( MembershipFeeValidator $feeValidator, BankDataValidator $bankDataValidator,
+	public function __construct( ValidateMembershipFeeUseCase $feeValidator, BankDataValidator $bankDataValidator,
 		IbanBlocklist $ibanBlocklist, EmailValidator $emailValidator ) {
 
 		$this->feeValidator = $feeValidator;
@@ -83,7 +84,7 @@ class MembershipApplicationValidator {
 
 	private function getApplicantType(): string {
 		return $this->request->isCompanyApplication() ?
-			MembershipFeeValidator::APPLICANT_TYPE_COMPANY : MembershipFeeValidator::APPLICANT_TYPE_PERSON;
+			ValidateMembershipFeeUseCase::APPLICANT_TYPE_COMPANY : ValidateMembershipFeeUseCase::APPLICANT_TYPE_PERSON;
 	}
 
 	private function addViolations( array $violations ): void {

--- a/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership;
 
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeRequest;
+use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeResult;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidationResult;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidator;
@@ -81,7 +82,18 @@ class MembershipApplicationValidator {
 				->withInterval( $this->request->getPaymentIntervalInMonths() )
 		);
 
-		$this->addViolations( $result->getViolations() );
+		if ( !$result->isSuccessful() ) {
+			$this->addPaymentAmountViolation(
+				[
+					ValidateFeeResult::ERROR_NOT_MONEY => ApplicationValidationResult::VIOLATION_NOT_MONEY,
+					ValidateFeeResult::ERROR_TOO_LOW => ApplicationValidationResult::VIOLATION_TOO_LOW
+				][$result->getErrorCode()]
+			);
+		}
+	}
+
+	private function addPaymentAmountViolation( string $violation ) {
+		$this->violations[ApplicationValidationResult::SOURCE_PAYMENT_AMOUNT] = $violation;
 	}
 
 	private function getApplicantType(): string {

--- a/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership;
 
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
+use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidationResult;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidator;
@@ -74,9 +75,10 @@ class MembershipApplicationValidator {
 
 	private function validateFee(): void {
 		$result = $this->feeValidator->validate(
-			$this->request->getPaymentAmountInEuros(),
-			$this->request->getPaymentIntervalInMonths(),
-			$this->getApplicantType()
+			ValidateFeeRequest::newInstance()
+				->withFee( $this->request->getPaymentAmountInEuros() )
+				->withApplicantType( $this->getApplicantType() )
+				->withInterval( $this->request->getPaymentIntervalInMonths() )
 		);
 
 		$this->addViolations( $result->getViolations() );

--- a/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
@@ -85,7 +85,6 @@ class MembershipApplicationValidator {
 		if ( !$result->isSuccessful() ) {
 			$this->addPaymentAmountViolation(
 				[
-					ValidateFeeResult::ERROR_NOT_MONEY => ApplicationValidationResult::VIOLATION_NOT_MONEY,
 					ValidateFeeResult::ERROR_TOO_LOW => ApplicationValidationResult::VIOLATION_TOO_LOW
 				][$result->getErrorCode()]
 			);

--- a/src/UseCases/ApplyForMembership/MembershipFeeValidator.php
+++ b/src/UseCases/ApplyForMembership/MembershipFeeValidator.php
@@ -21,8 +21,8 @@ class MembershipFeeValidator {
 	private const MIN_COMPANY_YEARLY_PAYMENT_IN_EURO = 100;
 	private const MONTHS_PER_YEAR = 12;
 
-	const APPLICANT_TYPE_COMPANY = 'firma';
-	const APPLICANT_TYPE_PERSON = 'person';
+	public const APPLICANT_TYPE_COMPANY = 'firma';
+	public const APPLICANT_TYPE_PERSON = 'person';
 
 	private $membershipFee;
 	private $paymentIntervalInMonths;

--- a/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 
+use WMDE\Euro\Euro;
+
 class ValidateFeeRequest {
 
 	public const PERSON_APPLICANT = 'person';
@@ -17,7 +19,7 @@ class ValidateFeeRequest {
 		return new self();
 	}
 
-	public function withFee( string $membershipFee ): self {
+	public function withFee( Euro $membershipFee ): self {
 		$request = clone $this;
 		$request->membershipFee = $membershipFee;
 		return $request;
@@ -35,7 +37,7 @@ class ValidateFeeRequest {
 		return $request;
 	}
 
-	public function getMembershipFee(): string {
+	public function getMembershipFee(): Euro {
 		return $this->membershipFee;
 	}
 

--- a/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
+
+/**
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ValidateFeeRequest {
+
+	public const PERON_APPLICANT = 'person';
+	public const COMPANY_APPLICANT = 'firma';
+
+	private $membershipFee;
+	private $paymentIntervalInMonths;
+	private $applicantType;
+
+	public static function newInstance(): self {
+		return new self();
+	}
+
+	public function withFee( string $membershipFee ): self {
+		$request = clone $this;
+		$request->membershipFee = $membershipFee;
+		return $request;
+	}
+
+	public function withInterval( int $paymentIntervalInMonths ): self {
+		$request = clone $this;
+		$request->paymentIntervalInMonths = $paymentIntervalInMonths;
+		return $request;
+	}
+
+	public function withApplicantType( string $applicantType ): self {
+		$request = clone $this;
+		$request->applicantType = $applicantType;
+		return $request;
+	}
+
+	public function getMembershipFee(): string {
+		return $this->membershipFee;
+	}
+
+	public function getPaymentIntervalInMonths(): int {
+		return $this->paymentIntervalInMonths;
+	}
+
+	public function getApplicantType(): string {
+		return $this->applicantType;
+	}
+
+}

--- a/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
@@ -10,7 +10,7 @@ namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
  */
 class ValidateFeeRequest {
 
-	public const PERON_APPLICANT = 'person';
+	public const PERSON_APPLICANT = 'person';
 	public const COMPANY_APPLICANT = 'firma';
 
 	private $membershipFee;

--- a/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateFeeRequest.php
@@ -4,10 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 
-/**
- * @license GNU GPL v2+
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- */
 class ValidateFeeRequest {
 
 	public const PERSON_APPLICANT = 'person';

--- a/src/UseCases/ValidateMembershipFee/ValidateFeeResult.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateFeeResult.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
+
+/**
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ValidateFeeResult {
+
+	public const ERROR_TOO_LOW = 'error-too-low';
+	public const ERROR_NOT_MONEY = 'error-not-money';
+
+	private $errorCode;
+
+	public static function newSuccessResponse(): self {
+		return new self();
+	}
+
+	public static function newNotMoneyResponse(): self {
+		return self::newErrorResponse( self::ERROR_NOT_MONEY );
+	}
+
+	public static function newTooLowResponse(): self {
+		return self::newErrorResponse( self::ERROR_TOO_LOW );
+	}
+
+	private static function newErrorResponse( string $errorCode ): self {
+		$result = new self();
+		$result->errorCode = $errorCode;
+		return $result;
+	}
+
+	private function __construct() {
+	}
+
+	public function isSuccessful(): bool {
+		return $this->errorCode === null;
+	}
+
+	public function getErrorCode(): ?string {
+		return $this->errorCode;
+	}
+
+}

--- a/src/UseCases/ValidateMembershipFee/ValidateFeeResult.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateFeeResult.php
@@ -7,16 +7,11 @@ namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 class ValidateFeeResult {
 
 	public const ERROR_TOO_LOW = 'error-too-low';
-	public const ERROR_NOT_MONEY = 'error-not-money';
 
 	private $errorCode;
 
 	public static function newSuccessResponse(): self {
 		return new self();
-	}
-
-	public static function newNotMoneyResponse(): self {
-		return self::newErrorResponse( self::ERROR_NOT_MONEY );
 	}
 
 	public static function newTooLowResponse(): self {

--- a/src/UseCases/ValidateMembershipFee/ValidateFeeResult.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateFeeResult.php
@@ -4,10 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 
-/**
- * @license GNU GPL v2+
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- */
 class ValidateFeeResult {
 
 	public const ERROR_TOO_LOW = 'error-too-low';

--- a/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
@@ -7,9 +7,6 @@ namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 use InvalidArgumentException;
 use WMDE\Euro\Euro;
 
-/**
- * @license GNU GPL v2+
- */
 class ValidateMembershipFeeUseCase {
 
 	private const MIN_PERSON_YEARLY_PAYMENT_IN_EURO = 24;

--- a/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
@@ -2,20 +2,18 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership;
+namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 
 use InvalidArgumentException;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
 
 /**
- * TODO: move outside this UC directory as it is used by things other than the UC (a route in FF app)
- *
  * @license GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class MembershipFeeValidator {
+class ValidateMembershipFeeUseCase {
 
 	private const MIN_PERSON_YEARLY_PAYMENT_IN_EURO = 24;
 	private const MIN_COMPANY_YEARLY_PAYMENT_IN_EURO = 100;

--- a/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 
-use InvalidArgumentException;
 use WMDE\Euro\Euro;
 
 class ValidateMembershipFeeUseCase {
@@ -16,7 +15,11 @@ class ValidateMembershipFeeUseCase {
 	public const APPLICANT_TYPE_COMPANY = 'firma';
 	public const APPLICANT_TYPE_PERSON = 'person';
 
+	/**
+	 * @var Euro
+	 */
 	private $membershipFee;
+
 	private $paymentIntervalInMonths;
 	private $applicantType;
 
@@ -25,22 +28,15 @@ class ValidateMembershipFeeUseCase {
 		$this->paymentIntervalInMonths = $request->getPaymentIntervalInMonths();
 		$this->applicantType = $request->getApplicantType();
 
-		try {
-			$amount = Euro::newFromString( $this->membershipFee );
-		}
-		catch ( InvalidArgumentException $ex ) {
-			return ValidateFeeResult::newNotMoneyResponse();
-		}
-
-		if ( $this->getYearlyPaymentAmount( $amount ) < $this->getYearlyPaymentRequirement() ) {
+		if ( $this->getYearlyPaymentAmount() < $this->getYearlyPaymentRequirement() ) {
 			return ValidateFeeResult::newTooLowResponse();
 		}
 
 		return ValidateFeeResult::newSuccessResponse();
 	}
 
-	private function getYearlyPaymentAmount( Euro $amount ): float {
-		return $amount->getEuroFloat() * self::MONTHS_PER_YEAR / $this->paymentIntervalInMonths;
+	private function getYearlyPaymentAmount(): float {
+		return $this->membershipFee->getEuroFloat() * self::MONTHS_PER_YEAR / $this->paymentIntervalInMonths;
 	}
 
 	private function getYearlyPaymentRequirement(): float {

--- a/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
@@ -10,8 +10,6 @@ use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationVa
 
 /**
  * @license GNU GPL v2+
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
 class ValidateMembershipFeeUseCase {
 
@@ -31,10 +29,11 @@ class ValidateMembershipFeeUseCase {
 	 */
 	private $violations;
 
-	public function validate( string $membershipFee, int $paymentIntervalInMonths, string $applicantType ): Result {
-		$this->membershipFee = $membershipFee;
-		$this->paymentIntervalInMonths = $paymentIntervalInMonths;
-		$this->applicantType = $applicantType;
+	public function validate( ValidateFeeRequest $request ): Result {
+		$this->membershipFee = $request->getMembershipFee();
+		$this->paymentIntervalInMonths = $request->getPaymentIntervalInMonths();
+		$this->applicantType = $request->getApplicantType();
+
 		$this->violations = [];
 
 		$this->validateAmount();

--- a/tests/Data/ValidMembershipApplicationRequest.php
+++ b/tests/Data/ValidMembershipApplicationRequest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\Tests\Data;
 
+use WMDE\Euro\Euro;
 use WMDE\Fundraising\MembershipContext\Tracking\MembershipApplicationTrackingInfo;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipRequest;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
@@ -48,7 +49,7 @@ class ValidMembershipApplicationRequest {
 		$request->setMembershipType( ValidMembershipApplication::MEMBERSHIP_TYPE );
 		$request->setPaymentType( ValidMembershipApplication::PAYMENT_TYPE_DIRECT_DEBIT );
 		$request->setPaymentIntervalInMonths( ValidMembershipApplication::PAYMENT_PERIOD_IN_MONTHS );
-		$request->setPaymentAmountInEuros( (string)ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO );
+		$request->setPaymentAmountInEuros( Euro::newFromInt( ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO ) );
 
 		$request->setTrackingInfo( $this->newTrackingInfo() );
 		$request->setPiwikTrackingString( 'foo/bar' );

--- a/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\MembershipContext\Tests\Integration\UseCases\ApplyFor
 
 use PHPUnit\Framework\TestCase;
 use WMDE\EmailAddress\EmailAddress;
+use WMDE\Euro\Euro;
 use WMDE\Fundraising\MembershipContext\Authorization\ApplicationTokenFetcher;
 use WMDE\Fundraising\MembershipContext\Authorization\MembershipApplicationTokens;
 use WMDE\Fundraising\MembershipContext\Authorization\MembershipTokenGenerator;
@@ -148,7 +149,7 @@ class ApplyForMembershipUseCaseTest extends TestCase {
 		$request->setApplicantDateOfBirth( ValidMembershipApplication::APPLICANT_DATE_OF_BIRTH );
 		$request->setPaymentType( ValidMembershipApplication::PAYMENT_TYPE_DIRECT_DEBIT );
 		$request->setPaymentIntervalInMonths( ValidMembershipApplication::PAYMENT_PERIOD_IN_MONTHS );
-		$request->setPaymentAmountInEuros( (string)ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO );
+		$request->setPaymentAmountInEuros( Euro::newFromInt( ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO ) );
 
 		$request->setBankData( $this->newValidBankData() );
 
@@ -296,7 +297,7 @@ class ApplyForMembershipUseCaseTest extends TestCase {
 		$request->setApplicantDateOfBirth( ValidMembershipApplication::APPLICANT_DATE_OF_BIRTH );
 		$request->setPaymentType( ValidMembershipApplication::PAYMENT_TYPE_PAYPAL );
 		$request->setPaymentIntervalInMonths( ValidMembershipApplication::PAYMENT_PERIOD_IN_MONTHS );
-		$request->setPaymentAmountInEuros( (string)ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO );
+		$request->setPaymentAmountInEuros( Euro::newFromInt( ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO ) );
 		$request->setBankData( new BankData() );
 
 		$request->setTrackingInfo( $this->newTrackingInfo() );

--- a/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
+++ b/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
@@ -60,7 +60,7 @@ class MembershipApplicationBuilderTest extends TestCase {
 		$request->setApplicantEmailAddress( ValidMembershipApplication::APPLICANT_EMAIL_ADDRESS );
 		$request->setPaymentType( ValidMembershipApplication::PAYMENT_TYPE_DIRECT_DEBIT );
 		$request->setPaymentIntervalInMonths( ValidMembershipApplication::PAYMENT_PERIOD_IN_MONTHS );
-		$request->setPaymentAmountInEuros( (string)ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO );
+		$request->setPaymentAmountInEuros( Euro::newFromInt( ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO ) );
 		$request->setBankData( $this->newValidBankData() );
 		$request->setApplicantPhoneNumber(
 			$omitOptionalFields ? '' : ValidMembershipApplication::APPLICANT_PHONE_NUMBER

--- a/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -10,6 +10,7 @@ use WMDE\Fundraising\MembershipContext\Tests\Fixtures\SucceedingEmailValidator;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipApplicationValidator;
+use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeResult;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidationResult as BankResult;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidator;
@@ -32,7 +33,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 	private const BLOCKED_IBAN = 'LU761111000872960000';
 
 	/*
-	 * @var MembershipFeeValidator
+	 * @var ValidateMembershipFeeUseCase
 	 */
 	private $feeValidator;
 
@@ -89,21 +90,19 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	private function newFailingFeeValidator(): ValidateMembershipFeeUseCase {
-		$feeValidator = $this->getMockBuilder( ValidateMembershipFeeUseCase::class )
-			->disableOriginalConstructor()->getMock();
+		$feeValidator = $this->createMock( ValidateMembershipFeeUseCase::class );
 
 		$feeValidator->method( 'validate' )
-			->willReturn( $this->newFeeViolationResult() );
+			->willReturn( ValidateFeeResult::newNotMoneyResponse() );
 
 		return $feeValidator;
 	}
 
 	private function newSucceedingFeeValidator(): ValidateMembershipFeeUseCase {
-		$feeValidator = $this->getMockBuilder( ValidateMembershipFeeUseCase::class )
-			->disableOriginalConstructor()->getMock();
+		$feeValidator = $this->createMock( ValidateMembershipFeeUseCase::class );
 
 		$feeValidator->method( 'validate' )
-			->willReturn( new Result() );
+			->willReturn( ValidateFeeResult::newSuccessResponse() );
 
 		return $feeValidator;
 	}

--- a/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -10,18 +10,18 @@ use WMDE\Fundraising\MembershipContext\Tests\Fixtures\SucceedingEmailValidator;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipApplicationValidator;
+use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidationResult as BankResult;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidator;
 use WMDE\Fundraising\PaymentContext\Domain\IbanBlocklist;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
 use WMDE\FunValidators\ConstraintViolation;
-use WMDE\FunValidators\Validators\EmailValidator;
-use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipFeeValidator;
 use WMDE\FunValidators\ValidationResult;
+use WMDE\FunValidators\Validators\EmailValidator;
 
 /**
- * @covers \WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipFeeValidator
+ * @covers \WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase
  *
  * @license GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
@@ -88,8 +88,8 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		return new IbanBlocklist( [] );
 	}
 
-	private function newFailingFeeValidator(): MembershipFeeValidator {
-		$feeValidator = $this->getMockBuilder( MembershipFeeValidator::class )
+	private function newFailingFeeValidator(): ValidateMembershipFeeUseCase {
+		$feeValidator = $this->getMockBuilder( ValidateMembershipFeeUseCase::class )
 			->disableOriginalConstructor()->getMock();
 
 		$feeValidator->method( 'validate' )
@@ -98,8 +98,8 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		return $feeValidator;
 	}
 
-	private function newSucceedingFeeValidator(): MembershipFeeValidator {
-		$feeValidator = $this->getMockBuilder( MembershipFeeValidator::class )
+	private function newSucceedingFeeValidator(): ValidateMembershipFeeUseCase {
+		$feeValidator = $this->getMockBuilder( ValidateMembershipFeeUseCase::class )
 			->disableOriginalConstructor()->getMock();
 
 		$feeValidator->method( 'validate' )

--- a/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -93,7 +93,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		$feeValidator = $this->createMock( ValidateMembershipFeeUseCase::class );
 
 		$feeValidator->method( 'validate' )
-			->willReturn( ValidateFeeResult::newNotMoneyResponse() );
+			->willReturn( ValidateFeeResult::newTooLowResponse() );
 
 		return $feeValidator;
 	}
@@ -113,7 +113,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 
 	private function newFeeViolationResult(): Result {
 		return new Result( [
-			Result::SOURCE_PAYMENT_AMOUNT => Result::VIOLATION_NOT_MONEY
+			Result::SOURCE_PAYMENT_AMOUNT => Result::VIOLATION_TOO_LOW
 		] );
 	}
 

--- a/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
+++ b/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
@@ -20,7 +20,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$response = $this->newUseCase()->validate(
 			ValidateFeeRequest::newInstance()
 				->withFee( '12.34' )
-				->withApplicantType( ValidateFeeRequest::PERON_APPLICANT )
+				->withApplicantType( ValidateFeeRequest::PERSON_APPLICANT )
 				->withInterval( 3 )
 		);
 
@@ -39,7 +39,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$response = $this->newUseCase()->validate(
 			ValidateFeeRequest::newInstance()
 				->withFee( $amount )
-				->withApplicantType( ValidateFeeRequest::PERON_APPLICANT )
+				->withApplicantType( ValidateFeeRequest::PERSON_APPLICANT )
 				->withInterval( $intervalInMonths )
 		);
 

--- a/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
+++ b/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\Tests\Unit\UseCases\ValidateMembershipFee;
 
-use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
+use WMDE\Euro\Euro;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeResult;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
@@ -19,7 +19,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 	public function testGivenValidRequest_validationSucceeds(): void {
 		$response = $this->newUseCase()->validate(
 			ValidateFeeRequest::newInstance()
-				->withFee( '12.34' )
+				->withFee( Euro::newFromString( '12.34' ) )
 				->withApplicantType( ValidateFeeRequest::PERSON_APPLICANT )
 				->withInterval( 3 )
 		);
@@ -38,7 +38,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 	public function testGivenInvalidAmount_validationFails( string $amount, int $intervalInMonths, string $expectedError ): void {
 		$response = $this->newUseCase()->validate(
 			ValidateFeeRequest::newInstance()
-				->withFee( $amount )
+				->withFee( Euro::newFromString( $amount ) )
 				->withApplicantType( ValidateFeeRequest::PERSON_APPLICANT )
 				->withInterval( $intervalInMonths )
 		);
@@ -48,9 +48,6 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function invalidAmountProvider(): iterable {
-		yield 'invalid: negative' => [ '-1.00', 3, ValidateFeeResult::ERROR_NOT_MONEY ];
-		yield 'invalid' => [ 'y u no btc', 3, ValidateFeeResult::ERROR_NOT_MONEY ];
-
 		yield 'too low single payment' => [ '1.00', 12, ValidateFeeResult::ERROR_TOO_LOW ];
 		yield 'just too low single payment' => [ '23.99', 12, ValidateFeeResult::ERROR_TOO_LOW ];
 		yield 'max too low single payment' => [ '0', 12, ValidateFeeResult::ERROR_TOO_LOW ];
@@ -67,7 +64,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 			$this->newUseCase()
 				->validate(
 					ValidateFeeRequest::newInstance()
-						->withFee( $amount )
+						->withFee( Euro::newFromString( $amount ) )
 						->withApplicantType( 'person' )
 						->withInterval( $intervalInMonths )
 				)
@@ -89,7 +86,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 			$this->newUseCase()
 				->validate(
 					ValidateFeeRequest::newInstance()
-						->withFee( '100.00' )
+						->withFee( Euro::newFromString( '100.00' ) )
 						->withApplicantType( ValidateFeeRequest::COMPANY_APPLICANT )
 						->withInterval( 12 )
 				)
@@ -102,7 +99,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 			$this->newUseCase()
 				->validate(
 					ValidateFeeRequest::newInstance()
-						->withFee( '99.99' )
+						->withFee( Euro::newFromString( '99.99' ) )
 						->withApplicantType( ValidateFeeRequest::COMPANY_APPLICANT )
 						->withInterval( 12 )
 				)

--- a/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
+++ b/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\MembershipContext\Tests\Unit\UseCases\ValidateMembers
 
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeRequest;
+use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeResult;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
 
 /**
@@ -23,9 +24,8 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 				->withInterval( 3 )
 		);
 
-		$this->assertEquals( new Result( [] ), $response );
-		$this->assertEmpty( $response->getViolationSources() );
 		$this->assertTrue( $response->isSuccessful() );
+		$this->assertNull( $response->getErrorCode() );
 	}
 
 	private function newUseCase(): ValidateMembershipFeeUseCase {
@@ -35,7 +35,7 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider invalidAmountProvider
 	 */
-	public function testGivenInvalidAmount_validationFails( string $amount, int $intervalInMonths, string $expectedViolation ): void {
+	public function testGivenInvalidAmount_validationFails( string $amount, int $intervalInMonths, string $expectedError ): void {
 		$response = $this->newUseCase()->validate(
 			ValidateFeeRequest::newInstance()
 				->withFee( $amount )
@@ -44,20 +44,19 @@ class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertFalse( $response->isSuccessful() );
-		$this->assertContains( Result::SOURCE_PAYMENT_AMOUNT, $response->getViolationSources() );
-		$this->assertSame( $expectedViolation, $response->getViolationType( Result::SOURCE_PAYMENT_AMOUNT ) );
+		$this->assertSame( $expectedError, $response->getErrorCode() );
 	}
 
 	public function invalidAmountProvider(): iterable {
-		yield 'invalid: negative' => [ '-1.00', 3, Result::VIOLATION_NOT_MONEY ];
-		yield 'invalid' => [ 'y u no btc', 3, Result::VIOLATION_NOT_MONEY ];
+		yield 'invalid: negative' => [ '-1.00', 3, ValidateFeeResult::ERROR_NOT_MONEY ];
+		yield 'invalid' => [ 'y u no btc', 3, ValidateFeeResult::ERROR_NOT_MONEY ];
 
-		yield 'too low single payment' => [ '1.00', 12, Result::VIOLATION_TOO_LOW ];
-		yield 'just too low single payment' => [ '23.99', 12, Result::VIOLATION_TOO_LOW ];
-		yield 'max too low single payment' => [ '0', 12, Result::VIOLATION_TOO_LOW ];
+		yield 'too low single payment' => [ '1.00', 12, ValidateFeeResult::ERROR_TOO_LOW ];
+		yield 'just too low single payment' => [ '23.99', 12, ValidateFeeResult::ERROR_TOO_LOW ];
+		yield 'max too low single payment' => [ '0', 12, ValidateFeeResult::ERROR_TOO_LOW ];
 
-		yield 'too low 12 times' => [ '1.99', 1, Result::VIOLATION_TOO_LOW ];
-		yield 'too low 4 times' => [ '5.99', 3, Result::VIOLATION_TOO_LOW ];
+		yield 'too low 12 times' => [ '1.99', 1, ValidateFeeResult::ERROR_TOO_LOW ];
+		yield 'too low 4 times' => [ '5.99', 3, ValidateFeeResult::ERROR_TOO_LOW ];
 	}
 
 	/**

--- a/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
+++ b/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
@@ -2,21 +2,21 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\MembershipContext\Tests\Unit\UseCases\ApplyForMembership;
+namespace WMDE\Fundraising\MembershipContext\Tests\Unit\UseCases\ValidateMembershipFee;
 
 use WMDE\Fundraising\MembershipContext\Tests\Data\ValidMembershipApplicationRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipRequest;
-use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipFeeValidator;
+use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
 
 /**
- * @covers \WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipFeeValidator
+ * @covers \WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase
  *
  * @license GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
+class ValidateMembershipFeeUseCaseTest extends \PHPUnit\Framework\TestCase {
 
 	public function testGivenValidRequest_validationSucceeds(): void {
 		$validRequest = $this->newValidRequest();
@@ -31,8 +31,8 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $response->isSuccessful() );
 	}
 
-	private function newValidator(): MembershipFeeValidator {
-		return new MembershipFeeValidator();
+	private function newValidator(): ValidateMembershipFeeUseCase {
+		return new ValidateMembershipFeeUseCase();
 	}
 
 	private function newValidRequest(): ApplyForMembershipRequest {


### PR DESCRIPTION
I was pointing some people at this component as example and then noticed the MembershipFeeValidator to be violating our own architecture rules. (Which was already indicated by the FIXME.) It is a service that looks private to one UseCase but is used from outside of the Bounded Context. I turned it into a dedicated BC now.