### PR TITLE
Improve version requirements of FundraisingStore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"psr/log": "~1.0",
 		"pimple/pimple": "~3.0",
 
-		"wmde/fundraising-store": "~10.1.0",
+		"wmde/fundraising-store": "~10.1",
 		"wmde/fundraising-payments": "@dev",
 		"wmde/euro": "~1.0",
 		"wmde/email-address": "~1.0",


### PR DESCRIPTION
Using the minor version should suffice and will ease the update pain
when minor, non-BC breaking features are introduced (as in
wmde/FundraisingStore#157)