### PR TITLE
Add validation for membership type

### DIFF
--- a/src/UseCases/ApplyForMembership/ApplicationValidationResult.php
+++ b/src/UseCases/ApplyForMembership/ApplicationValidationResult.php
@@ -22,6 +22,7 @@ class ApplicationValidationResult {
 	public const SOURCE_APPLICANT_POSTAL_CODE = 'postal-code';
 	public const SOURCE_APPLICANT_CITY = 'city';
 	public const SOURCE_APPLICANT_COUNTRY = 'country-code';
+	public const SOURCE_APPLICANT_MEMBERSHIP_TYPE = 'membership-type';
 
 	public const VIOLATION_TOO_LOW = 'too-low';
 	public const VIOLATION_WRONG_LENGTH = 'wrong-length';
@@ -31,6 +32,7 @@ class ApplicationValidationResult {
 	public const VIOLATION_NOT_DATE = 'not-date';
 	public const VIOLATION_NOT_PHONE_NUMBER = 'not-phone';
 	public const VIOLATION_NOT_EMAIL = 'not-email';
+	public const VIOLATION_INVALID_MEMBERSHIP_TYPE = 'invalid-membership-type';
 
 	private $violations;
 

--- a/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
@@ -8,6 +8,7 @@ use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationVa
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeResult;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
+use WMDE\Fundraising\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidationResult;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidator;
 use WMDE\Fundraising\PaymentContext\Domain\IbanBlocklist;
@@ -61,6 +62,7 @@ class MembershipApplicationValidator {
 		$this->request = $applicationRequest;
 		$this->violations = [];
 
+		$this->validateMembershipType();
 		$this->validateFee();
 		$this->validateApplicantName();
 		$this->validateApplicantContactInfo();
@@ -72,6 +74,13 @@ class MembershipApplicationValidator {
 		}
 
 		return new Result( $this->violations );
+	}
+
+	private function validateMembershipType(): void {
+		$membershiptype = $this->request->getMembershipType();
+		if ( $membershiptype !== Application::ACTIVE_MEMBERSHIP && $membershiptype !== Application::SUSTAINING_MEMBERSHIP ) {
+			$this->violations[Result::SOURCE_APPLICANT_MEMBERSHIP_TYPE] = Result::VIOLATION_INVALID_MEMBERSHIP_TYPE;
+		}
 	}
 
 	private function validateFee(): void {

--- a/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -314,6 +314,16 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
+	public function testWhenMembershipTypeIsMissing_validationFails(): void {
+		$request = $this->newValidRequest();
+		$request->setMembershipType( '' );
+
+		$this->assertRequestValidationResultInErrors(
+			$request,
+			[ Result::SOURCE_APPLICANT_MEMBERSHIP_TYPE => Result::VIOLATION_INVALID_MEMBERSHIP_TYPE ]
+		);
+	}
+
 	public function testPhoneNumberIsNotProvided_validationDoesNotFail(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantPhoneNumber( '' );


### PR DESCRIPTION
There was only a client side validation on the membership type,
now there is also server side validation that checks whether
the type is 'active' or 'sustaining'.