### PR TITLE
Increase PHPStan level to 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ fix-cs:
 	docker-compose run --rm app ./vendor/bin/phpcbf
 
 stan:
-	docker-compose run --rm app ./vendor/bin/phpstan analyse --level=1 --no-progress src/ tests/
+	docker-compose run --rm app php -d memory_limit=1G vendor/bin/phpstan analyse --level=5 --no-progress src/ tests/
 
 setup: install-php
 


### PR DESCRIPTION
Commit 7e8c849da40f500b2ec9db4539bb969be7401abc increased the possible
PHPStan level without actually increasing it. This commit increases it
in the build process.