### PR TITLE
Add DoctrineIncentiveFinder

### DIFF
--- a/src/DataAccess/DoctrineIncentiveFinder.php
+++ b/src/DataAccess/DoctrineIncentiveFinder.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\MembershipContext\DataAccess;
+
+use Doctrine\ORM\EntityManager;
+use WMDE\Fundraising\MembershipContext\Domain\Model\Incentive;
+
+class DoctrineIncentiveFinder implements IncentiveFinder {
+
+	private EntityManager $entityManager;
+
+	public function __construct( EntityManager $entityManager ) {
+		$this->entityManager = $entityManager;
+	}
+
+	public function findIncentiveByName( string $name ): ?Incentive {
+		return $this->entityManager->getRepository( Incentive::class )->findOneBy( [ 'name' => $name ] );
+	}
+}

--- a/tests/Integration/DataAccess/DoctrineIncentiveFinderTest.php
+++ b/tests/Integration/DataAccess/DoctrineIncentiveFinderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\MembershipContext\Tests\Integration\DataAccess;
+
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineIncentiveFinder;
+use WMDE\Fundraising\MembershipContext\Domain\Model\Incentive;
+use WMDE\Fundraising\MembershipContext\Tests\TestEnvironment;
+
+/**
+ * @covers \WMDE\Fundraising\MembershipContext\DataAccess\DoctrineIncentiveFinder
+ */
+class DoctrineIncentiveFinderTest extends TestCase {
+
+	private const MISSING_INCENTIVE = 'Diamond-studded fountain pen';
+	private const EXPECTED_INCENTIVE = 'Eternal Gratitude';
+
+	private EntityManager $entityManager;
+
+	protected function setUp(): void {
+		$this->entityManager = TestEnvironment::newInstance()->getEntityManager();
+	}
+
+	public function testEmptyIncentiveTableReturnsNoIncentive(): void {
+		$finder = new DoctrineIncentiveFinder( $this->entityManager );
+
+		$incentive = $finder->findIncentiveByName( self::MISSING_INCENTIVE );
+
+		$this->assertNull( $incentive );
+	}
+
+	public function testGivenNonMatchingName_finderReturnsNoIncentive(): void {
+		$this->insertExpectedIncentive();
+		$finder = new DoctrineIncentiveFinder( $this->entityManager );
+
+		$incentive = $finder->findIncentiveByName( self::MISSING_INCENTIVE );
+
+		$this->assertNull( $incentive );
+	}
+
+	public function testGivenMatchingName_finderReturnsIncentive(): void {
+		$this->insertExpectedIncentive();
+		$finder = new DoctrineIncentiveFinder( $this->entityManager );
+
+		$incentive = $finder->findIncentiveByName( self::EXPECTED_INCENTIVE );
+
+		$this->assertNotNull( $incentive );
+		$this->assertSame( self::EXPECTED_INCENTIVE, $incentive->getName() );
+	}
+
+	private function insertExpectedIncentive() {
+		$this->entityManager->persist( new Incentive( self::EXPECTED_INCENTIVE ) );
+		$this->entityManager->flush();
+	}
+
+}


### PR DESCRIPTION
The DoctrineIncentiveFinder uses the database to find incentives. We
will use this class in production.

This is for https://phabricator.wikimedia.org/T282432
