### PR TITLE
Check platform requirements in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 install:
-  - travis_retry composer install --prefer-dist --no-interaction --ignore-platform-reqs
+  - travis_retry composer install --prefer-dist --no-interaction
 
 script:
   - make ci


### PR DESCRIPTION
Remove `--ignore-platform-reqs` when installing with composer. This
should fix an issue where we install PHP 7.4 incompatible versions
of psr/cache
