### PR TITLE
Improve external payments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 
 		"psr/log": "~1.0",
 
-		"wmde/fundraising-payments": "~2.1",
+		"wmde/fundraising-payments": "~2.2",
 		"wmde/euro": "~1.0",
 		"wmde/email-address": "~1.0",
 		"wmde/fun-validators": "~3.0.0",

--- a/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
+++ b/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
@@ -120,11 +120,7 @@ class DomainToLegacyConverter {
 			return DoctrineApplication::STATUS_CANCELED;
 		}
 
-		if ( !$application->getPayment()->getPaymentMethod()->hasExternalProvider() ) {
-			return DoctrineApplication::STATUS_CONFIRMED;
-		}
-
-		if ( $application->getPayment()->getPaymentMethod()->paymentCompleted() ) {
+		if ( $application->isConfirmed() ) {
 			return DoctrineApplication::STATUS_CONFIRMED;
 		}
 

--- a/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
+++ b/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
@@ -44,10 +44,6 @@ class LegacyToDomainConverter {
 			$application->markForModeration();
 		}
 
-		if ( $doctrineApplication->isConfirmed() ) {
-			$application->confirm();
-		}
-
 		if ( $doctrineApplication->isCancelled() ) {
 			$application->cancel();
 		}

--- a/src/Domain/Model/MembershipApplication.php
+++ b/src/Domain/Model/MembershipApplication.php
@@ -27,7 +27,7 @@ class MembershipApplication {
 	private Payment $payment;
 	private bool $moderationNeeded = false;
 	private bool $cancelled = false;
-	private bool $confirmed = false;
+	private bool $confirmed = true;
 	private bool $exported = false;
 	private ?bool $donationReceipt;
 	/** @var Incentive[] */
@@ -39,6 +39,10 @@ class MembershipApplication {
 		$this->applicant = $applicant;
 		$this->payment = $payment;
 		$this->donationReceipt = $donationReceipt;
+		$paymentMethod = $payment->getPaymentMethod();
+		if ( $paymentMethod instanceof BookablePayment ) {
+			$this->confirmed = $paymentMethod->paymentCompleted();
+		}
 	}
 
 	public function getId(): ?int {
@@ -124,10 +128,6 @@ class MembershipApplication {
 		return true;
 	}
 
-	public function confirm(): void {
-		$this->confirmed = true;
-	}
-
 	public function setExported(): void {
 		$this->exported = true;
 	}
@@ -147,7 +147,7 @@ class MembershipApplication {
 		}
 
 		$paymentMethod->bookPayment( $paymentTransactionData );
-		$this->confirm();
+		$this->confirmed = true;
 	}
 
 	private function statusAllowsForBooking(): bool {

--- a/src/Domain/Model/MembershipApplication.php
+++ b/src/Domain/Model/MembershipApplication.php
@@ -151,7 +151,8 @@ class MembershipApplication {
 	}
 
 	private function statusAllowsForBooking(): bool {
-		return !$this->isConfirmed() || $this->needsModeration() || $this->isCancelled();
+		return !$this->isConfirmed() &&
+			!$this->needsModeration();
 	}
 
 	public function notifyOfFirstPaymentDate( string $firstPaymentDate ): void {

--- a/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
+++ b/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
@@ -125,7 +125,6 @@ class HandleSubscriptionPaymentNotificationUseCase {
 			),
 			$application->getDonationReceipt()
 		);
-		$childApplication->confirm();
 
 		try {
 			$this->repository->storeApplication( $childApplication );

--- a/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
+++ b/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
@@ -60,10 +60,8 @@ class HandleSubscriptionSignupNotificationUseCase {
 			return $this->createUnhandledResponse( 'Wrong access code for membership application' );
 		}
 
-		$paymentMethod->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
-
 		try {
-			$application->confirmSubscriptionCreated();
+			$application->confirmSubscriptionCreated( $this->newPayPalDataFromRequest( $request ) );
 		} catch ( \RuntimeException $ex ) {
 			return $this->createErrorResponse( $ex );
 		}

--- a/tests/Data/ValidMembershipApplication.php
+++ b/tests/Data/ValidMembershipApplication.php
@@ -61,6 +61,9 @@ class ValidMembershipApplication {
 	public const PAYMENT_BIC = 'INGDDEFFXXX';
 	public const PAYMENT_IBAN = 'DE12500105170648489890';
 
+	public const PAYPAL_TRANSACTION_ID = '61E67681CH3238416';
+	public const PAYPAL_PAYER_ID = 'HE373U84ENFYQ';
+
 	public const TEMPLATE_CAMPAIGN = 'test161012';
 	public const TEMPLATE_NAME = 'Some_Membership_Form_Template.twig';
 	public const FIRST_PAYMENT_DATE = '2021-02-01';
@@ -77,12 +80,6 @@ class ValidMembershipApplication {
 			$self->newPayment(),
 			self::OPTS_INTO_DONATION_RECEIPT
 		);
-	}
-
-	public static function newAutoConfirmedDomainEntity(): MembershipApplication {
-		$application = self::newDomainEntity();
-		$application->confirm();
-		return $application;
 	}
 
 	public static function newCompanyApplication(): MembershipApplication {
@@ -125,19 +122,16 @@ class ValidMembershipApplication {
 	public static function newConfirmedSubscriptionDomainEntity(): MembershipApplication {
 		$self = ( new self() );
 
-		$payPalData = ( new PayPalData() )
+		$payPalData = self::newBookedPayPalData()
 			->setSubscriberId( 'subscription_id' );
 
-		$application = new MembershipApplication(
+		return new MembershipApplication(
 			null,
 			self::MEMBERSHIP_TYPE,
 			$self->newApplicant( $self->newPersonApplicantName() ),
 			$self->newPayPalPayment( $payPalData ),
 			self::OPTS_INTO_DONATION_RECEIPT
 		);
-		$application->confirm();
-
-		return $application;
 	}
 
 	private function newApplicant( ApplicantName $name ): Applicant {
@@ -235,13 +229,20 @@ class ValidMembershipApplication {
 		return new Payment(
 			self::PAYMENT_PERIOD_IN_MONTHS,
 			Euro::newFromFloat( self::PAYMENT_AMOUNT_IN_EURO ),
-			new PayPalPayment( $payPalData ?: $this->newPayPalData() )
+			new PayPalPayment( $payPalData ?: self::newPayPalData() )
 		);
 	}
 
-	private function newPayPalData(): PayPalData {
+	public static function newPayPalData(): PayPalData {
 		$payPalData = new PayPalData();
 		$payPalData->setFirstPaymentDate( self::FIRST_PAYMENT_DATE );
+		return $payPalData;
+	}
+
+	public static function newBookedPayPalData(): PayPalData {
+		$payPalData = self::newPayPalData();
+		$payPalData->setPayerId( self::PAYPAL_PAYER_ID );
+		$payPalData->setPaymentId( self::PAYPAL_TRANSACTION_ID );
 		return $payPalData;
 	}
 

--- a/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
@@ -83,7 +83,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 	public function testWhenMembershipApplicationInDatabase_itIsReturnedAsMatchingDomainEntity(): void {
 		$this->storeDoctrineApplication( ValidMembershipApplication::newDoctrineEntity() );
 
-		$expected = ValidMembershipApplication::newAutoConfirmedDomainEntity();
+		$expected = ValidMembershipApplication::newDomainEntity();
 		$expected->assignId( self::MEMBERSHIP_APPLICATION_ID );
 
 		$this->assertEquals(
@@ -128,7 +128,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 
 	public function testWriteAndReadRoundtrip(): void {
 		$repository = $this->newRepository();
-		$application = ValidMembershipApplication::newAutoConfirmedDomainEntity();
+		$application = ValidMembershipApplication::newDomainEntity();
 
 		$repository->storeApplication( $application );
 

--- a/tests/Integration/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCaseTest.php
+++ b/tests/Integration/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCaseTest.php
@@ -94,11 +94,10 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends TestCase {
 		$this->assertFalse( $response->notificationWasHandled() );
 	}
 
-	public function testWhenStatusIsNotAllowedForConfirming_requestIsNotHandled(): void {
+	public function testWhenMembershipIsAlreadyConfirmed_requestIsNotHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 
-		$application = ValidMembershipApplication::newDomainEntityUsingPayPal();
-		$application->confirm();
+		$application = ValidMembershipApplication::newDomainEntityUsingPayPal( ValidMembershipApplication::newBookedPayPalData() );
 		$fakeRepository->storeApplication( $application );
 
 		$useCase = new HandleSubscriptionSignupNotificationUseCase(

--- a/tests/Integration/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCaseTest.php
+++ b/tests/Integration/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCaseTest.php
@@ -26,10 +26,7 @@ use WMDE\Fundraising\MembershipContext\UseCases\HandleSubscriptionSignupNotifica
  */
 class HandleSubscriptionSignupNotificationUseCaseTest extends TestCase {
 
-	/**
-	 * @var TemplateBasedMailerSpy
-	 */
-	private $mailerSpy;
+	private TemplateBasedMailerSpy $mailerSpy;
 
 	public function setUp(): void {
 		$this->mailerSpy = new TemplateBasedMailerSpy( $this );

--- a/tests/Unit/Domain/Model/MembershipApplicationTest.php
+++ b/tests/Unit/Domain/Model/MembershipApplicationTest.php
@@ -105,4 +105,22 @@ class MembershipApplicationTest extends TestCase {
 		$application->cancel();
 	}
 
+	public function testMembershipsWithNonBookablePaymentsAreAutomaticallyConfirmed(): void {
+		$application = ValidMembershipApplication::newDomainEntity();
+
+		$this->assertTrue( $application->isConfirmed() );
+	}
+
+	public function testMembershipsWithUnBookedPaymentsAreNotConfirmed(): void {
+		$application = ValidMembershipApplication::newDomainEntityUsingPayPal( ValidMembershipApplication::newPayPalData() );
+
+		$this->assertFalse( $application->isConfirmed() );
+	}
+
+	public function testMembershipsWithBookedPaymentsAreConfirmed(): void {
+		$application = ValidMembershipApplication::newDomainEntityUsingPayPal( ValidMembershipApplication::newBookedPayPalData() );
+
+		$this->assertTrue( $application->isConfirmed() );
+	}
+
 }

--- a/tests/Unit/LegacyConverters/DomainToLegacyConverterTest.php
+++ b/tests/Unit/LegacyConverters/DomainToLegacyConverterTest.php
@@ -46,8 +46,8 @@ class DomainToLegacyConverterTest extends TestCase {
 
 	public function testWhenPersistingApplicationWithConfirmedFlag_doctrineApplicationHasFlag(): void {
 		$doctrineApplication = new DoctrineApplication();
+		// Direct debit payments are auto-confirmed
 		$application = ValidMembershipApplication::newDomainEntity();
-		$application->confirm();
 
 		$converter = new DomainToLegacyConverter();
 		$converter->convert( $doctrineApplication, $application );


### PR DESCRIPTION
Use new BookablePayment interface to handle payment confirmation.
Use new BookablePayment interface to determine confirmed state.

Add tests for confirmSubscriptionCreated.

Refactor statusAllowsForBooking and remove isDeleted check because that
state of a membership can't be created any more.

