### PR TITLE
Fix adding incentives to membership applications

### DIFF
--- a/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
@@ -115,7 +115,7 @@ class MembershipApplicationBuilder {
 			if ( $foundIncentive === null ) {
 				throw new UnknownIncentive( sprintf( 'Incentive "%s" not found', $incentiveName ) );
 			}
-			$application->addIncentive( new Incentive( $incentiveName ) );
+			$application->addIncentive( $foundIncentive );
 		}
 	}
 

--- a/tests/Fixtures/TestIncentiveFinder.php
+++ b/tests/Fixtures/TestIncentiveFinder.php
@@ -9,7 +9,25 @@ use WMDE\Fundraising\MembershipContext\Domain\Model\Incentive;
 
 class TestIncentiveFinder implements IncentiveFinder {
 
+	/**
+	 * @var Incentive[]
+	 */
+	private array $incentives;
+
+	/**
+	 * @param Incentive[] $incentives
+	 */
+	public function __construct( array $incentives ) {
+		$this->incentives = $incentives;
+	}
+
 	public function findIncentiveByName( string $name ): ?Incentive {
-		return new Incentive( $name );
+		$incentives = array_filter( $this->incentives, fn( $incentive ) => $incentive->getName() === $name );
+
+		if ( count( $incentives ) === 0 ) {
+			return null;
+		}
+
+		return reset( $incentives );
 	}
 }

--- a/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -11,6 +11,7 @@ use WMDE\Fundraising\MembershipContext\Authorization\ApplicationTokenFetcher;
 use WMDE\Fundraising\MembershipContext\Authorization\MembershipApplicationTokens;
 use WMDE\Fundraising\MembershipContext\Authorization\MembershipTokenGenerator;
 use WMDE\Fundraising\MembershipContext\Domain\Event\MembershipCreatedEvent;
+use WMDE\Fundraising\MembershipContext\Domain\Model\Incentive;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\ApplicationRepository;
 use WMDE\Fundraising\MembershipContext\EventEmitter;
 use WMDE\Fundraising\MembershipContext\Tests\Data\ValidMembershipApplication;
@@ -116,7 +117,7 @@ class ApplyForMembershipUseCaseTest extends TestCase {
 			$this->piwikTracker,
 			$this->newFixedPaymentDelayCalculator(),
 			$this->eventEmitter,
-			new TestIncentiveFinder()
+			new TestIncentiveFinder( [ new Incentive( 'I AM INCENTIVE' ) ] )
 		);
 	}
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T285101

Incentives were being added to the MembershipApplication
without an id. This made Doctrine want to add a new Incentive
when a membership was saved, which caused an error to be thrown.

This fixes that error and adds tests to ensure Incentives have IDs
when added to a MembershipApplication