### PR TITLE
Improve interval validation

### DIFF
--- a/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
@@ -25,7 +25,7 @@ class ValidateMembershipFeeUseCase {
 		$this->paymentIntervalInMonths = $request->getPaymentIntervalInMonths();
 		$this->applicantType = $request->getApplicantType();
 
-		if ( $this->paymentIntervalInMonths < 1 ) {
+		if ( !in_array( $this->paymentIntervalInMonths, [ 1, 3, 6, 12 ] ) ) {
 			return ValidateFeeResult::newIntervalInvalidResponse();
 		}
 


### PR DESCRIPTION
When validating user input, check for valid interval lengths. This is an
additional safeguard to prevent a `InvalidArgumentException` (a
logic error, not a runtime error) when constructing membership fees.
