### PR TITLE
Remove test files from production autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"WMDE\\Fundraising\\MembershipContext\\": "src/",
-			"WMDE\\Fundraising\\MembershipContext\\Tests\\Data\\": "tests/Data/",
-			"WMDE\\Fundraising\\MembershipContext\\Tests\\Fixtures\\": "tests/Fixtures/"
+			"WMDE\\Fundraising\\MembershipContext\\": "src/"
 		}
 	},
 	"autoload-dev": {


### PR DESCRIPTION
These shouldn't be there because we don't need test classes in production