### PR TITLE
Add Symfony Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
 	],
 	"require-dev": {
 		"phpunit/phpunit": "~9.5.0",
+		"symfony/cache": "^5.3",
 		"codeception/specify": "~1.0",
 		"phpstan/phpstan": "~0.11",
 		"wmde/fundraising-phpcs": "~3.0",


### PR DESCRIPTION
Doctrine v2.9 removed internal caching so we now need Symfony's one as a dependency