### PR TITLE
Remove external coverage from Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,5 +1,4 @@
 tools:
-    external_code_coverage: true
     php_code_sniffer: true
     php_cpd: false
     php_cs_fixer: true
@@ -24,6 +23,4 @@ build:
                 override:
                 - php-scrutinizer-run
                 - phpcs-run
-    tests:
-        override:
-        - true
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,9 @@ install:
   - travis_retry composer install --prefer-dist --no-interaction
 
 script:
-  - make ci-with-coverage COVERAGE_FLAGS="--coverage-clover coverage.clover"
+  - make ci
   - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
   - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 5 --no-progress src/ # Can't use "make stan" because stan was removed
-
-after_success:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 
 cache:
   directories:


### PR DESCRIPTION
Since the coverage uploader is not compatible with PHP 8, we generate
coverage information with scrutinizer.
