### PR TITLE
Add Payment Data to ConfirmationPresenter

### DIFF
--- a/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationPresenter.php
+++ b/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationPresenter.php
@@ -6,13 +6,16 @@ namespace WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmatio
 
 use WMDE\Fundraising\MembershipContext\Domain\Model\MembershipApplication;
 
-/**
- * @license GPL-2.0-or-later
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- */
 interface ShowApplicationConfirmationPresenter {
 
-	public function presentConfirmation( MembershipApplication $application, string $updateToken ): void;
+	/**
+	 * @param MembershipApplication $application
+	 * @param array<string,mixed> $paymentData
+	 * @param string $updateToken
+	 *
+	 * @return void
+	 */
+	public function presentConfirmation( MembershipApplication $application, array $paymentData, string $updateToken ): void;
 
 	public function presentApplicationWasAnonymized(): void;
 

--- a/tests/Integration/UseCases/ShowApplicationConfirmation/FakeShowApplicationConfirmationPresenter.php
+++ b/tests/Integration/UseCases/ShowApplicationConfirmation/FakeShowApplicationConfirmationPresenter.php
@@ -14,22 +14,28 @@ use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\Show
 class FakeShowApplicationConfirmationPresenter implements ShowApplicationConfirmationPresenter {
 
 	private $application;
+	private $paymentData;
 	private $updateToken;
 	private $anonymizedResponseWasShown = false;
 	private $accessViolationWasShown = false;
 	private $shownTechnicalError;
 
-	public function presentConfirmation( MembershipApplication $application, string $updateToken ): void {
+	public function presentConfirmation( MembershipApplication $application, array $paymentData, string $updateToken ): void {
 		if ( $this->application !== null ) {
 			throw new \RuntimeException( 'Presenter should only be invoked once' );
 		}
 
 		$this->application = $application;
+		$this->paymentData = $paymentData;
 		$this->updateToken = $updateToken;
 	}
 
 	public function getShownApplication(): MembershipApplication {
 		return $this->application;
+	}
+
+	public function getShownPaymentData(): array {
+		return $this->paymentData;
 	}
 
 	public function getShownUpdateToken(): string {

--- a/tests/Integration/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCaseTest.php
+++ b/tests/Integration/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCaseTest.php
@@ -14,6 +14,7 @@ use WMDE\Fundraising\MembershipContext\Tests\Fixtures\FixedApplicationTokenFetch
 use WMDE\Fundraising\MembershipContext\Tests\Fixtures\SucceedingAuthorizer;
 use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\ShowAppConfirmationRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\ShowApplicationConfirmationUseCase;
+use WMDE\Fundraising\PaymentContext\UseCases\GetPayment\GetPaymentUseCase;
 
 /**
  * @covers \WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\ShowApplicationConfirmationUseCase
@@ -24,6 +25,10 @@ use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\Show
 class ShowApplicationConfirmationUseCaseTest extends TestCase {
 
 	private const APPLICATION_ID = 42;
+	private const PAYMENT_DATA = [
+		'anything' => 'can',
+		'go' => 'here',
+	];
 
 	/**
 	 * @var FakeShowApplicationConfirmationPresenter
@@ -68,11 +73,15 @@ class ShowApplicationConfirmationUseCaseTest extends TestCase {
 	}
 
 	private function newUseCase(): ShowApplicationConfirmationUseCase {
+		$getPaymentUseCase = $this->createStub( GetPaymentUseCase::class );
+		$getPaymentUseCase->method( 'getPaymentDataArray' )->willReturn( self::PAYMENT_DATA );
+
 		return new ShowApplicationConfirmationUseCase(
 			$this->presenter,
 			$this->authorizer,
 			$this->repository,
-			$this->tokenFetcher
+			$this->tokenFetcher,
+			$getPaymentUseCase
 		);
 	}
 
@@ -82,6 +91,11 @@ class ShowApplicationConfirmationUseCaseTest extends TestCase {
 		$this->assertSame(
 			self::APPLICATION_ID,
 			$this->presenter->getShownApplication()->getId()
+		);
+
+		$this->assertSame(
+			self::PAYMENT_DATA,
+			$this->presenter->getShownPaymentData()
 		);
 
 		$this->assertSame(


### PR DESCRIPTION
This adds an array parameter to the Confirmation Presenter
to allow it to take in display data from the payment
when implemented in Fundraising Application

Ticket: https://phabricator.wikimedia.org/T305832