### PR TITLE
Make allowed payment types configurable

### DIFF
--- a/src/Domain/MembershipPaymentValidator.php
+++ b/src/Domain/MembershipPaymentValidator.php
@@ -49,11 +49,15 @@ class MembershipPaymentValidator implements DomainSpecificPaymentValidator {
 
 	private Euro $membershipFee;
 	private PaymentInterval $paymentIntervalInMonths;
-	private ApplicantType $applicantType;
 	private PaymentType $paymentType;
 
-	public function __construct( ApplicantType $applicantType ) {
-		$this->applicantType = $applicantType;
+	/**
+	 * @param ApplicantType $applicantType
+	 * @param PaymentType[] $allowedPaymentTypes
+	 */
+	public function __construct(
+		private ApplicantType $applicantType,
+		private array $allowedPaymentTypes ) {
 	}
 
 	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentType $paymentType ): ValidationResponse {
@@ -102,6 +106,6 @@ class MembershipPaymentValidator implements DomainSpecificPaymentValidator {
 	}
 
 	private function isInvalidPaymentTypeForMemberships( PaymentType $paymentType ): bool {
-		return $paymentType !== PaymentType::DirectDebit;
+		return !in_array( $paymentType, $this->allowedPaymentTypes );
 	}
 }

--- a/src/Infrastructure/PaymentServiceFactory.php
+++ b/src/Infrastructure/PaymentServiceFactory.php
@@ -1,0 +1,32 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\Infrastructure;
+
+use WMDE\Fundraising\MembershipContext\Domain\MembershipPaymentValidator;
+use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicantType;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
+use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\CreatePaymentUseCase;
+
+/**
+ * This class is for passing down dependencies from a higher layer (Fundraising Application) to the use cases
+ */
+class PaymentServiceFactory {
+
+	/**
+	 * @param CreatePaymentUseCase $useCase
+	 * @param PaymentType[] $allowedPaymentTypes
+	 */
+	public function __construct(
+		private CreatePaymentUseCase $useCase,
+		private array $allowedPaymentTypes ) {
+	}
+
+	public function getCreatePaymentUseCase(): CreatePaymentUseCase {
+		return $this->useCase;
+	}
+
+	public function newPaymentValidator( ApplicantType $applicantType ): MembershipPaymentValidator {
+		return new MembershipPaymentValidator( $applicantType, $this->allowedPaymentTypes );
+	}
+}

--- a/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\MembershipContext\Domain\MembershipPaymentValidator;
+use WMDE\Fundraising\MembershipContext\Infrastructure\PaymentServiceFactory;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicantType;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentValidator;
 use WMDE\FunValidators\ConstraintViolation;
@@ -15,6 +15,9 @@ class ValidateMembershipFeeUseCase {
 
 	public const SOURCE_APPLICANT_TYPE = 'applicant-type';
 	public const INVALID_APPLICANT_TYPE = 'invalid-applicant-type';
+
+	public function __construct( private PaymentServiceFactory $paymentServiceFactory ) {
+	}
 
 	public function validate( int $membershipFeeInEuro, int $paymentInterval, string $applicantTypeName, string $paymentType ): ValidationResponse {
 		$applicantType = ApplicantType::tryFrom( $applicantTypeName );
@@ -26,7 +29,7 @@ class ValidateMembershipFeeUseCase {
 			);
 		}
 
-		$domainSpecificValidator = new MembershipPaymentValidator( $applicantType );
+		$domainSpecificValidator = $this->paymentServiceFactory->newPaymentValidator( $applicantType );
 		$validator = new PaymentValidator();
 		return $validator->validatePaymentData( $membershipFeeInEuroCents, $paymentInterval, $paymentType, $domainSpecificValidator );
 	}

--- a/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -15,6 +15,7 @@ use WMDE\Fundraising\MembershipContext\Domain\Model\Incentive;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\ApplicationRepository;
 use WMDE\Fundraising\MembershipContext\EventEmitter;
 use WMDE\Fundraising\MembershipContext\Infrastructure\MembershipConfirmationMailer;
+use WMDE\Fundraising\MembershipContext\Infrastructure\PaymentServiceFactory;
 use WMDE\Fundraising\MembershipContext\Tests\Data\ValidMembershipApplication;
 use WMDE\Fundraising\MembershipContext\Tests\Fixtures\EventEmitterSpy;
 use WMDE\Fundraising\MembershipContext\Tests\Fixtures\FixedApplicationTokenFetcher;
@@ -32,6 +33,7 @@ use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipApp
 use WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator\PaymentProviderURLGenerator;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\CreatePaymentUseCase;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\FailureResponse;
@@ -352,7 +354,10 @@ class ApplyForMembershipUseCaseTest extends TestCase {
 			$piwikTracker ?? $this->createMock( ApplicationPiwikTracker::class ),
 			$eventEmitter ?? $this->createMock( EventEmitter::class ),
 			$incentiveFinder ?? new TestIncentiveFinder( [ new Incentive( 'I AM INCENTIVE' ) ] ),
-			$createPaymentUseCase ?? $this->newSucceedingCreatePaymentUseCase()
+			new PaymentServiceFactory(
+				$createPaymentUseCase ?? $this->newSucceedingCreatePaymentUseCase(),
+				[ PaymentType::DirectDebit ]
+			)
 		);
 	}
 

--- a/tests/Unit/UseCases/ApplyForMembership/MembershipPaymentValidatorTest.php
+++ b/tests/Unit/UseCases/ApplyForMembership/MembershipPaymentValidatorTest.php
@@ -20,11 +20,15 @@ class MembershipPaymentValidatorTest extends TestCase {
 	public const VALID_MIN_AMOUNT_FOR_COMPANY = 100;
 	public const VALID_MIN_AMOUNT_FOR_PRIVATE_PERSON = 24;
 
+	public const ALLOWED_PAYMENT_TYPES = [
+		PaymentType::DirectDebit
+	];
+
 	/**
 	 * @dataProvider companyAmountProvider
 	 */
 	public function testGivenValidFeeAmountForCompany_validatorReturnsNoViolations( bool $isValid, int $amount ): void {
-		$validator = new MembershipPaymentValidator( ApplicantType::COMPANY_APPLICANT );
+		$validator = new MembershipPaymentValidator( ApplicantType::COMPANY_APPLICANT, self::ALLOWED_PAYMENT_TYPES );
 		$response = $validator->validatePaymentData(
 			Euro::newFromInt( $amount ),
 			PaymentInterval::Yearly,
@@ -37,7 +41,7 @@ class MembershipPaymentValidatorTest extends TestCase {
 	 * @dataProvider privatePersonAmountProvider
 	 */
 	public function testGivenValidFeeAmountForPrivatePerson_validatorReturnsNoViolations( bool $isValid, int $amount ): void {
-		$validator = new MembershipPaymentValidator( ApplicantType::PERSON_APPLICANT );
+		$validator = new MembershipPaymentValidator( ApplicantType::PERSON_APPLICANT, self::ALLOWED_PAYMENT_TYPES );
 		$response = $validator->validatePaymentData(
 			Euro::newFromInt( $amount ),
 			PaymentInterval::Yearly,
@@ -62,7 +66,7 @@ class MembershipPaymentValidatorTest extends TestCase {
 	 * @dataProvider tooLowAmountProvider
 	 */
 	public function testGivenFeeAmountTooLowPerYear_validatorReturnsErrors( ApplicantType $applicantType, int $lowAmount ): void {
-		$validator = new MembershipPaymentValidator( $applicantType );
+		$validator = new MembershipPaymentValidator( $applicantType, self::ALLOWED_PAYMENT_TYPES );
 		$response = $validator->validatePaymentData(
 			Euro::newFromInt( $lowAmount ),
 			PaymentInterval::Quarterly,
@@ -84,7 +88,7 @@ class MembershipPaymentValidatorTest extends TestCase {
 	}
 
 	public function testInvalidIntervalForMemberships_validatorReturnsErrors(): void {
-		$validator = new MembershipPaymentValidator( ApplicantType::COMPANY_APPLICANT );
+		$validator = new MembershipPaymentValidator( ApplicantType::COMPANY_APPLICANT, self::ALLOWED_PAYMENT_TYPES );
 		$invalidInterval = PaymentInterval::OneTime;
 		$response = $validator->validatePaymentData(
 			 Euro::newFromInt( ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO ),
@@ -98,7 +102,7 @@ class MembershipPaymentValidatorTest extends TestCase {
 	 * @dataProvider validIntervalProvider
 	 */
 	public function testValidIntervalForMemberships_validatorReturnsNoErrors( PaymentInterval $validInterval ): void {
-		$validator = new MembershipPaymentValidator( ApplicantType::COMPANY_APPLICANT );
+		$validator = new MembershipPaymentValidator( ApplicantType::COMPANY_APPLICANT, self::ALLOWED_PAYMENT_TYPES );
 		$response = $validator->validatePaymentData(
 			Euro::newFromInt( 100 ),
 			$validInterval,
@@ -118,7 +122,7 @@ class MembershipPaymentValidatorTest extends TestCase {
 	 * @dataProvider invalidPaymentTypeProvider
 	 */
 	public function testInvalidPaymentTypesForMemberships_validatorReturnsErrors( PaymentType $invalidPaymentType ): void {
-		$validator = new MembershipPaymentValidator( ApplicantType::PERSON_APPLICANT );
+		$validator = new MembershipPaymentValidator( ApplicantType::PERSON_APPLICANT, self::ALLOWED_PAYMENT_TYPES );
 		$response = $validator->validatePaymentData(
 			Euro::newFromInt( ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO ),
 			ValidMembershipApplication::PAYMENT_PERIOD_IN_MONTHS,
@@ -131,6 +135,7 @@ class MembershipPaymentValidatorTest extends TestCase {
 		yield [ PaymentType::BankTransfer ];
 		yield [ PaymentType::Sofort ];
 		yield [ PaymentType::CreditCard ];
+		yield [ PaymentType::Paypal ];
 	}
 
 }


### PR DESCRIPTION
Change MembershipPaymentValidator to check a list of allowed payment
types instead of hard-coding them. The list will be passed from an upper
layer (Fundraising Application) into to PaymentServiceFactory

This is a preparation for https://phabricator.wikimedia.org/T312087