### PR TITLE
Move ModerationIdentifier Doctrine type

### DIFF
--- a/src/DataAccess/DoctrineTypes/ModerationIdentifier.php
+++ b/src/DataAccess/DoctrineTypes/ModerationIdentifier.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities;
+namespace WMDE\Fundraising\MembershipContext\DataAccess\DoctrineTypes;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;

--- a/src/MembershipContextFactory.php
+++ b/src/MembershipContextFactory.php
@@ -118,7 +118,7 @@ class MembershipContextFactory {
 		if ( $isRegistered ) {
 			return;
 		}
-		Type::addType( 'MembershipModerationIdentifier', 'WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\ModerationIdentifier' );
+		Type::addType( 'MembershipModerationIdentifier', 'WMDE\Fundraising\MembershipContext\DataAccess\DoctrineTypes\ModerationIdentifier' );
 		$connection->getDatabasePlatform()->registerDoctrineTypeMapping( 'MembershipModerationIdentifier', 'MembershipModerationIdentifier' );
 		$isRegistered = true;
 	}


### PR DESCRIPTION
It was misplaced in the DoctrineEntities namespace, but should be in the
DoctrineTypes.