### PR TITLE
Re-use migration db config

### DIFF
--- a/bin/check-membership-payment-data
+++ b/bin/check-membership-payment-data
@@ -4,18 +4,13 @@
 // A script to test data quality in donations for migration to the new payments
 // This can be deleted when the payment data has been migrated successfully in production
 
-use Doctrine\DBAL\DriverManager;
+use WMDE\Fundraising\MembershipContext\DataAccess\PaymentMigration\ConnectionFactory;
 use WMDE\Fundraising\MembershipContext\DataAccess\PaymentMigration\MembershipToPaymentConverter;
 use WMDE\Fundraising\MembershipContext\DataAccess\PaymentMigration\ResultObject;
 
 include $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
 
-$config = [
-	'url' => 'mysql://fundraising:INSECURE PASSWORD@database/fundraising'
-];
-
-
-$db = DriverManager::getConnection( $config );
+$db = ConnectionFactory::getConnection();
 $converter = new MembershipToPaymentConverter( $db );
 
 $result = $converter->convertMemberships();

--- a/src/DataAccess/PaymentMigration/ConnectionFactory.php
+++ b/src/DataAccess/PaymentMigration/ConnectionFactory.php
@@ -1,0 +1,35 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\DataAccess\PaymentMigration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
+
+/**
+ * Create a Doctrine DBAL Connection for the data migration scripts, re-using migration config
+ */
+class ConnectionFactory {
+	private const CONFIG_FILE = "migrations-db.php";
+
+	public static function getConnection(): Connection {
+		if ( !file_exists( self::CONFIG_FILE ) ) {
+			printf( "Database configuration file '%s' not found in %s\n", self::CONFIG_FILE, getcwd() );
+			die( 1 );
+		}
+		$config = include self::CONFIG_FILE;
+		if ( empty( $config ) ) {
+			printf( "Database configuration file '%s' did not contain configuration data\n", self::CONFIG_FILE );
+			die( 1 );
+		}
+
+		try {
+			$conn = DriverManager::getConnection( $config );
+		} catch ( Exception $e ) {
+			echo $e->getMessage() . "\n";
+			die( 1 );
+		}
+		return $conn;
+	}
+}

--- a/src/DataAccess/PaymentMigration/PaymentMigrationCommand.php
+++ b/src/DataAccess/PaymentMigration/PaymentMigrationCommand.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace WMDE\Fundraising\MembershipContext\DataAccess\PaymentMigration;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use WMDE\Fundraising\PaymentContext\PaymentContextFactory;
@@ -19,7 +18,7 @@ use WMDE\Fundraising\PaymentContext\PaymentContextFactory;
  */
 class PaymentMigrationCommand {
 	public static function run(): void {
-		$db = self::getConnection();
+		$db = ConnectionFactory::getConnection();
 		$entityManager = self::getEntityManager( $db );
 
 		$paymentIdCollection = new MembershipPaymentIdCollection();
@@ -55,19 +54,6 @@ class PaymentMigrationCommand {
 		$minId = intval( $db->fetchOne( "SELECT MIN(id) FROM request" ) ) - 1;
 		// return 0 when minId is -1 (meaning there were no rows)
 		return max( 0, $minId );
-	}
-
-	private static function getConnection(): Connection {
-		$dsn = $_SERVER['MYSQL_DSN'] ?? '';
-		if ( !$dsn || !preg_match( "#^mysql://\w+:[\w ]+@\w+/\w+#", $dsn ) ) {
-			echo "You must set the environment variable MYSQL_DSN before running this script!\n";
-			echo "Example shell command:\nexport MYSQL_DSN='mysql://fundraising:INSECURE PASSWORD@database/fundraising'\n";
-			die( 1 );
-		}
-
-		$config = [ 'url' => $dsn ];
-
-		return DriverManager::getConnection( $config );
 	}
 
 	private static function getEntityManager( Connection $db ): EntityManager {


### PR DESCRIPTION
Instead of hard-coding database connection or reading it from the
environment, let's re-use the config file from Doctrine migrations.
This will make it easier to use on the server.