### PR TITLE
Add payment restore to RestoreMembershipApplication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 
 		"psr/log": "~3.0",
 
-		"wmde/fundraising-payments": "~5.0",
+		"wmde/fundraising-payments": "~5.1",
 		"wmde/euro": "~1.0",
 		"wmde/email-address": "~1.0",
 		"wmde/fun-validators": "~4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 
 		"psr/log": "~3.0",
 
-		"wmde/fundraising-payments": "~5.1",
+		"wmde/fundraising-payments": "~5.2",
 		"wmde/euro": "~1.0",
 		"wmde/email-address": "~1.0",
 		"wmde/fun-validators": "~4.0.0",

--- a/src/UseCases/RestoreMembershipApplication/RestoreMembershipApplicationUseCase.php
+++ b/src/UseCases/RestoreMembershipApplication/RestoreMembershipApplicationUseCase.php
@@ -37,6 +37,10 @@ class RestoreMembershipApplicationUseCase {
 			return RestoreMembershipApplicationResponse::newFailureResponse( $membershipApplicationId );
 		}
 
+		if ( $cancelPaymentResponse->paymentIsCompleted ) {
+			$membershipApplication->confirm();
+		}
+
 		$membershipApplication->restore();
 		$this->applicationRepository->storeApplication( $membershipApplication );
 

--- a/tests/Integration/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCaseTest.php
+++ b/tests/Integration/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCaseTest.php
@@ -217,7 +217,7 @@ class CancelMembershipApplicationUseCaseTest extends TestCase {
 	private function givenSucceedingCancelPaymentUseCase(): CancelPaymentUseCase {
 		$useCase = $this->createMock( CancelPaymentUseCase::class );
 		$useCase->method( 'cancelPayment' )
-			->willReturn( new SuccessResponse() );
+			->willReturn( new SuccessResponse( true ) );
 		return $useCase;
 	}
 

--- a/tests/Unit/UseCases/RestoreMembershipApplication/RestoreMembershipApplicationUseCaseTest.php
+++ b/tests/Unit/UseCases/RestoreMembershipApplication/RestoreMembershipApplicationUseCaseTest.php
@@ -8,6 +8,9 @@ use WMDE\Fundraising\MembershipContext\Tests\Data\ValidMembershipApplication;
 use WMDE\Fundraising\MembershipContext\Tests\Fixtures\FakeApplicationRepository;
 use WMDE\Fundraising\MembershipContext\Tests\Fixtures\MembershipApplicationEventLoggerSpy;
 use WMDE\Fundraising\MembershipContext\UseCases\RestoreMembershipApplication\RestoreMembershipApplicationUseCase;
+use WMDE\Fundraising\PaymentContext\UseCases\CancelPayment\CancelPaymentUseCase;
+use WMDE\Fundraising\PaymentContext\UseCases\CancelPayment\FailureResponse;
+use WMDE\Fundraising\PaymentContext\UseCases\CancelPayment\SuccessResponse;
 
 /**
  * @covers \WMDE\Fundraising\MembershipContext\UseCases\RestoreMembershipApplication\RestoreMembershipApplicationUseCase
@@ -86,14 +89,38 @@ class RestoreMembershipApplicationUseCaseTest extends TestCase {
 		$this->assertContains( $message, $logs );
 	}
 
-	private function newUseCase( MembershipApplication ...$applications ): RestoreMembershipApplicationUseCase {
-		foreach ( $applications as $application ) {
+	public function testWhenPaymentRestorationFails_restorationFails(): void {
+		$application = ValidMembershipApplication::newDomainEntity();
+		$application->cancel();
+		$useCase = $this->newUseCase( $application, $this->givenFailingCancelPaymentUseCase() );
+
+		$response = $useCase->restoreApplication( $application->getId(), self::AUTH_USER_NAME );
+		$this->assertFalse( $response->isSuccess() );
+	}
+
+	private function newUseCase( ?MembershipApplication $application = null, ?CancelPaymentUseCase $cancelPaymentUseCase = null ): RestoreMembershipApplicationUseCase {
+		if ( $application !== null ) {
 			$this->applicationRepository->storeApplication( $application );
 		}
 
 		return new RestoreMembershipApplicationUseCase(
 			$this->applicationRepository,
-			$this->membershipApplicationEventLogger
+			$this->membershipApplicationEventLogger,
+			$cancelPaymentUseCase ?? $this->givenSucceedingCancelPaymentUseCase()
 		);
+	}
+
+	private function givenSucceedingCancelPaymentUseCase(): CancelPaymentUseCase {
+		$useCase = $this->createMock( CancelPaymentUseCase::class );
+		$useCase->method( 'restorePayment' )
+			->willReturn( new SuccessResponse() );
+		return $useCase;
+	}
+
+	private function givenFailingCancelPaymentUseCase(): CancelPaymentUseCase {
+		$useCase = $this->createMock( CancelPaymentUseCase::class );
+		$useCase->method( 'restorePayment' )
+			->willReturn( new FailureResponse( 'This payment is already cancelled' ) );
+		return $useCase;
 	}
 }


### PR DESCRIPTION
When a membership application is restored by an admin the payment should be un-cancelled.
Ticket: https://phabricator.wikimedia.org/T318217