### PR TITLE
Fix coverage information

### DIFF
--- a/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -46,7 +46,6 @@ use WMDE\Fundraising\PaymentContext\UseCases\GetPayment\GetPaymentUseCase;
  * @covers \WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipUseCase
  * @covers \WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipRequest
  * @covers \WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipResponse
- * @covers \WMDE\Fundraising\MembershipContext\Infrastructure\MembershipConfirmationMailer
  */
 class ApplyForMembershipUseCaseTest extends TestCase {
 
@@ -168,18 +167,11 @@ class ApplyForMembershipUseCaseTest extends TestCase {
 	}
 
 	public function testGivenValidRequest_confirmationEmailIsSent(): void {
-		$mailerSpy = new TemplateBasedMailerSpy( $this );
-		$notifier = new MailMembershipApplicationNotifier(
-			$mailerSpy,
-			new TemplateMailerStub(),
-			$this->makePaymentRetriever(),
-			'mitglieder@wikimedia.de'
-		);
+		$notifier = $this->createMock( MembershipNotifier::class );
+		$notifier->expects( $this->once() )->method( 'sendConfirmationFor' );
 
 		$this->makeUseCase( mailNotifier: $notifier )
 			->applyForMembership( $this->newValidRequest() );
-
-		$mailerSpy->expectToBeCalledOnce();
 	}
 
 	public function testGivenValidRequest_tokenIsGeneratedAndReturned(): void {

--- a/tests/Unit/UseCases/ApplyForMembership/MailMembershipApplicationNotifierTest.php
+++ b/tests/Unit/UseCases/ApplyForMembership/MailMembershipApplicationNotifierTest.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\Notification\
 use WMDE\Fundraising\PaymentContext\UseCases\GetPayment\GetPaymentUseCase;
 
 /**
- * @covers \WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MailTemplateValueBuilder
+ * @covers \WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\Notification\MailMembershipApplicationNotifier
  */
 class MailMembershipApplicationNotifierTest extends TestCase {
 


### PR DESCRIPTION
Two tests had the wrong coverage annotations, leading to warnings in CI.

The class `MembershipConfirmationMailer` no longer exists, it was a
duplicate implementation of `MembershipNotifier` and is replaced by
`MailMembershipApplicationNotifier`

ApplyForMembershipUseCaseTest no longer tests the mailer implementation,
so we can simplify the test.
