### PR TITLE
Use default release in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   app:
-    image: "registry.gitlab.com/fun-tech/fundraising-frontend-docker/php-8.1:latest"
+    image: "registry.gitlab.com/fun-tech/fundraising-frontend-docker"
     volumes:
       - ./:/usr/src/app
     working_dir: /usr/src/app


### PR DESCRIPTION
docker-compose was still using the test release of our container
