### PR TITLE
Allow Payment Bounded Context Version 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 
 		"psr/log": "~3.0",
 
-		"wmde/fundraising-payments": "~7.0",
+		"wmde/fundraising-payments": "~7.0|~8.0",
 		"wmde/euro": "~1.0",
 		"wmde/email-address": "~1.0",
 		"wmde/fun-validators": "~4.0.0",


### PR DESCRIPTION
This is an "anticipatory" change of for a BC break occurring in the
Payments bounded context that won't affect donations, only the
application. (see https://github.com/wmde/fundraising-payments/pull/147 )

This is for https://phabricator.wikimedia.org/T350149
