### PR TITLE
Handle Euro exceptions

### DIFF
--- a/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
+++ b/src/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCase.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee;
 
 use WMDE\Euro\Euro;
+use WMDE\Fundraising\MembershipContext\Domain\MembershipPaymentValidator;
 use WMDE\Fundraising\MembershipContext\Infrastructure\PaymentServiceFactory;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicantType;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentValidator;
@@ -20,9 +21,13 @@ class ValidateMembershipFeeUseCase {
 	}
 
 	public function validate( int $membershipFeeInEuro, int $paymentInterval, string $applicantTypeName, string $paymentType ): ValidationResponse {
-		$applicantType = ApplicantType::tryFrom( $applicantTypeName );
-		$membershipFeeInEuroCents = Euro::newFromInt( $membershipFeeInEuro )->getEuroCents();
+		try {
+			$membershipFeeInEuroCents = Euro::newFromInt( $membershipFeeInEuro )->getEuroCents();
+		} catch ( \InvalidArgumentException $e ) {
+			return $this->handleExceptionFromEuroCreation( $membershipFeeInEuro, $e );
+		}
 
+		$applicantType = ApplicantType::tryFrom( $applicantTypeName );
 		if ( $applicantType === null ) {
 			return ValidationResponse::newFailureResponse(
 				[ new ConstraintViolation( $applicantType, self::INVALID_APPLICANT_TYPE, self::SOURCE_APPLICANT_TYPE ) ]
@@ -32,6 +37,29 @@ class ValidateMembershipFeeUseCase {
 		$domainSpecificValidator = $this->paymentServiceFactory->newPaymentValidator( $applicantType );
 		$validator = new PaymentValidator();
 		return $validator->validatePaymentData( $membershipFeeInEuroCents, $paymentInterval, $paymentType, $domainSpecificValidator );
+	}
+
+	private function handleExceptionFromEuroCreation( int $membershipFeeInEuro, \InvalidArgumentException $e ): ValidationResponse {
+		// TODO We should modify the Euro class to throw a more specific exception, with numeric code
+		//      (as a constant in the exception class) instead of messages
+		if ( $e->getMessage() === 'Number is too big' ) {
+			return ValidationResponse::newFailureResponse(
+				[ new ConstraintViolation(
+					$membershipFeeInEuro,
+					MembershipPaymentValidator::FEE_TOO_HIGH,
+					MembershipPaymentValidator::SOURCE_MEMBERSHIP_FEE
+				) ]
+			);
+		} else {
+			// With the current implementation of the Euro class, this should never happen.
+			return ValidationResponse::newFailureResponse(
+				[ new ConstraintViolation(
+					$membershipFeeInEuro,
+					$e->getMessage(),
+					MembershipPaymentValidator::SOURCE_MEMBERSHIP_FEE
+				) ]
+			);
+		}
 	}
 
 }

--- a/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
+++ b/tests/Unit/UseCases/ValidateMembershipFee/ValidateMembershipFeeUseCaseTest.php
@@ -93,6 +93,32 @@ class ValidateMembershipFeeUseCaseTest extends TestCase {
 		);
 	}
 
+	public function testGivenLargeInteger_validationFailsWhenConstructingEuroClass(): void {
+		$fakePaymentValidator = $this->createMock( MembershipPaymentValidator::class );
+		$fakePaymentValidator->expects( $this->never() )->method( $this->anything() );
+		$stubbedFactory = $this->createStub( PaymentServiceFactory::class );
+		$stubbedFactory->method( 'newPaymentValidator' )->willReturn( $fakePaymentValidator );
+		$useCase = new ValidateMembershipFeeUseCase( $stubbedFactory );
+
+		$result = $useCase->validate( PHP_INT_MAX, 12, ApplicantType::PERSON_APPLICANT->value, "BEZ" );
+
+		$this->assertFalse( $result->isSuccessful() );
+		$this->assertSame( MembershipPaymentValidator::FEE_TOO_HIGH, $result->getValidationErrors()[0]->getMessageIdentifier() );
+	}
+
+	public function testGivenNegativeInteger_validationFailsWhenConstructingEuroClass(): void {
+		$fakePaymentValidator = $this->createMock( MembershipPaymentValidator::class );
+		$fakePaymentValidator->expects( $this->never() )->method( $this->anything() );
+		$stubbedFactory = $this->createStub( PaymentServiceFactory::class );
+		$stubbedFactory->method( 'newPaymentValidator' )->willReturn( $fakePaymentValidator );
+		$useCase = new ValidateMembershipFeeUseCase( $stubbedFactory );
+
+		$result = $useCase->validate( -5, 12, ApplicantType::PERSON_APPLICANT->value, "BEZ" );
+
+		$this->assertFalse( $result->isSuccessful() );
+		$this->assertNotSame( MembershipPaymentValidator::FEE_TOO_HIGH, $result->getValidationErrors()[0]->getMessageIdentifier() );
+	}
+
 	public function testGivenInvalidInterval_zero_validationFails() {
 		$useCase = $this->newUseCase();
 


### PR DESCRIPTION
Handle exceptions from `Euro` class in `ValidateMembershipFeeUseCase`.

Other code (e.g. membership creation) already expects Euro.
I looked at other places (e.g. notifier and DB legacy converter) that
call static `Euro` constructors, but in those cases the amount comes
from sources that other code has already validated, so we should not
catch exceptions there.
