### PR TITLE
Update Symfony to 7.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -16,7 +16,7 @@ filter:
 build:
     environment:
         php:
-            version: '8.1'
+            version: '8.2'
     nodes:
         analysis:
             tests:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ current_user   := $(shell id -u)
 current_group  := $(shell id -g)
 BUILD_DIR      := $(PWD)
 DOCKER_FLAGS   := --interactive --tty
-DOCKER_IMAGE   := registry.gitlab.com/fun-tech/fundraising-frontend-docker/php-8.1
+DOCKER_IMAGE   := registry.gitlab.com/fun-tech/fundraising-frontend-docker
 COVERAGE_FLAGS := --coverage-html coverage
 
 install-php:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"license": "GPL-2.0-or-later",
 	"description": "Bounded Context for the Wikimedia Deutschland fundraising membership subdomain",
 	"require": {
-		"php": ">=8.1",
+		"php": ">=8.2",
 
 		"doctrine/orm": "~2.18 | ~3.0",
 		"doctrine/migrations": "^3.5",
@@ -35,7 +35,7 @@
 	],
 	"require-dev": {
 		"phpunit/phpunit": "~10.4.0",
-		"symfony/cache": "^6.1",
+		"symfony/cache": "^6.1|^7.0",
 		"phpstan/phpstan": "~1.2",
 		"wmde/fundraising-phpcs": "~9.0.0",
 		"wmde/psr-log-test-doubles": "~3.0",

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   app_debug:
-    image: "registry.gitlab.com/fun-tech/fundraising-frontend-docker/php-8.1:xdebug"
+    image: "registry.gitlab.com/fun-tech/fundraising-frontend-docker:xdebug"
     environment:
       - XDEBUG_CONFIG=remote_host=${LOCAL_IP}
       - PHP_IDE_CONFIG=serverName=donation.spenden.wikimedia.de


### PR DESCRIPTION
Update all Symfony dependencies to 7.0. These are only dev dependencies.
We allow for 6.x version of the cache to ensure compatibility with an
un-updated payments version.

Checked the CHANGELOG files of each dependency and we don't have any
code that is affected by breaking changes

Remove special PHP 8.1 docker image reference from Makefile and docker-compose.debug.yml

Ticket: https://phabricator.wikimedia.org/T355689