### PR TITLE
Require coverage metadata in PHPUnit config  

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
 	stopOnFailure="false"
 	stopOnIncomplete="false"
 	cacheDirectory=".phpunit.cache"
+	requireCoverageMetadata="true"
 >
   <coverage includeUncoveredFiles="true"/>
   <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,15 @@
 <?xml version="1.0"?>
 <phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
-        bootstrap="tests/bootstrap.php"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	backupStaticProperties="false"
+	colors="true"
+	stopOnError="false"
+	stopOnFailure="false"
+	stopOnIncomplete="false"
+	cacheDirectory=".phpunit.cache"
 >
   <coverage includeUncoveredFiles="true"/>
   <testsuites>


### PR DESCRIPTION
PHPUnit should check for `@covers` annotations and/or `#CoversClass` PHP
attributes. This change will allow us to disable the check in our coding
style, which only supports annotations. The coding style rule would
block us from using attributes and PHPUnit 11 in the future.

Ticket: https://phabricator.wikimedia.org/T359971