### PR TITLE
Pre-check membership anonymization condition

### DIFF
--- a/src/DataAccess/DoctrineMembershipAnonymizer.php
+++ b/src/DataAccess/DoctrineMembershipAnonymizer.php
@@ -62,7 +62,27 @@ class DoctrineMembershipAnonymizer implements MembershipAnonymizer {
 
 	public function anonymizeWithIds( int ...$membershipIds ): void {
 		$gracePeriodCutoffDate = $this->clock->now()->sub( $this->gracePeriodForUnexportedData )->format( 'Y-m-d H:i:s' );
+		$countQuery = $this->conn->createQueryBuilder()->select( "COUNT(id)" )->from( self::TABLE_NAME );
+		$countQuery = $this->addConditionsForIdsAndExportState( $countQuery, $gracePeriodCutoffDate, ...$membershipIds );
+		$count = $countQuery->executeQuery()->fetchOne();
+		if ( !is_scalar( $count ) || intval( $count ) !== count( $membershipIds ) ) {
+			throw new AnonymizationException( sprintf(
+				"No membership found with IDs '%s' or some memberships are not exported",
+				implode( ", ", $membershipIds )
+			) );
+		}
+
 		$queryBuilder = $this->newUpdateQueryBuilder();
+		$queryBuilder = $this->addConditionsForIdsAndExportState( $queryBuilder, $gracePeriodCutoffDate, ...$membershipIds );
+
+		try {
+			$queryBuilder->executeStatement();
+		} catch ( \Exception $e ) {
+			throw new AnonymizationException( 'Could not update memberships.', 0, $e );
+		}
+	}
+
+	private function addConditionsForIdsAndExportState( QueryBuilder $queryBuilder, string $gracePeriodCutoffDate, int ...$membershipIds ): QueryBuilder {
 		$queryBuilder->where( 'id IN (:membershipIds)' )
 			->andWhere( $queryBuilder->expr()->or(
 				$queryBuilder->expr()->isNotNull( 'export' ),
@@ -70,18 +90,7 @@ class DoctrineMembershipAnonymizer implements MembershipAnonymizer {
 			) )
 			->setParameter( 'membershipIds', $membershipIds, ArrayParameterType::INTEGER )
 			->setParameter( 'creationTime', $gracePeriodCutoffDate, ParameterType::STRING );
-		try {
-			$rowCount = intval( $queryBuilder->executeStatement() );
-		} catch ( \Exception $e ) {
-			throw new AnonymizationException( 'Could not update memberships.', 0, $e );
-		}
-
-		if ( $rowCount !== count( $membershipIds ) ) {
-			throw new AnonymizationException( sprintf(
-				"No membership found with IDs '%s' or some memberships are not exported",
-				implode( ", ", $membershipIds )
-			) );
-		}
+		return $queryBuilder;
 	}
 
 	private function newUpdateQueryBuilder(): QueryBuilder {


### PR DESCRIPTION
`anonymizeWithIds` will now check the ID and export state conditions
before anonymizing memberships. This makes the call atomic instead of
best-effort.

Ticket: https://phabricator.wikimedia.org/T357517
