### PR TITLE
Output stored tracking

### DIFF
--- a/src/DataAccess/DoctrineApplicationPiwikTracker.php
+++ b/src/DataAccess/DoctrineApplicationPiwikTracker.php
@@ -33,4 +33,12 @@ class DoctrineApplicationPiwikTracker implements ApplicationPiwikTracker {
 		}
 	}
 
+	public function getApplicationTracking( int $applicationId ): string {
+		try {
+			return $this->table->getApplicationById( $applicationId )->getTracking() ?? '';
+		} catch ( GetMembershipApplicationException $e ) {
+			throw new ApplicationPiwikTrackingException( 'Could not find membership application', $e );
+		}
+	}
+
 }

--- a/src/Tracking/ApplicationPiwikTracker.php
+++ b/src/Tracking/ApplicationPiwikTracker.php
@@ -17,4 +17,10 @@ interface ApplicationPiwikTracker {
 	 */
 	public function trackApplication( int $applicationId, string $trackingString ): void;
 
+	/**
+	 * @param int $applicationId
+	 *
+	 * @throws ApplicationPiwikTrackingException
+	 */
+	public function getApplicationTracking( int $applicationId ): string;
 }

--- a/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationPresenter.php
+++ b/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationPresenter.php
@@ -11,10 +11,11 @@ interface ShowApplicationConfirmationPresenter {
 	/**
 	 * @param MembershipApplication $application
 	 * @param array<string,mixed> $paymentData
+	 * @param string $tracking
 	 *
 	 * @return void
 	 */
-	public function presentConfirmation( MembershipApplication $application, array $paymentData ): void;
+	public function presentConfirmation( MembershipApplication $application, array $paymentData, string $tracking ): void;
 
 	public function presentApplicationWasAnonymized(): void;
 

--- a/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCase.php
+++ b/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCase.php
@@ -8,6 +8,7 @@ use WMDE\Fundraising\MembershipContext\Authorization\MembershipAuthorizationChec
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\ApplicationAnonymizedException;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\GetMembershipApplicationException;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\MembershipRepository;
+use WMDE\Fundraising\MembershipContext\Tracking\ApplicationPiwikTracker;
 use WMDE\Fundraising\PaymentContext\UseCases\GetPayment\GetPaymentUseCase;
 
 class ShowApplicationConfirmationUseCase {
@@ -16,7 +17,8 @@ class ShowApplicationConfirmationUseCase {
 		private readonly ShowApplicationConfirmationPresenter $presenter,
 		private readonly MembershipAuthorizationChecker $authorizer,
 		private readonly MembershipRepository $repository,
-		private readonly GetPaymentUseCase $getPaymentUseCase
+		private readonly GetPaymentUseCase $getPaymentUseCase,
+		private readonly ApplicationPiwikTracker $piwikTracker,
 	) {
 	}
 
@@ -28,6 +30,7 @@ class ShowApplicationConfirmationUseCase {
 
 		try {
 			$application = $this->repository->getUnexportedMembershipApplicationById( $request->getApplicationId() );
+			$tracking = $this->piwikTracker->getApplicationTracking( $request->getApplicationId() );
 
 			// This is here to make phpstan happy, the authorizer already checks for non-existing membership applications
 			if ( $application === null ) {
@@ -48,6 +51,7 @@ class ShowApplicationConfirmationUseCase {
 			// TODO: use DTO instead of Entity (currently violates the architecture)
 			$application,
 			$paymentData,
+			$tracking,
 		);
 	}
 

--- a/tests/Integration/UseCases/ShowApplicationConfirmation/FakeShowApplicationConfirmationPresenter.php
+++ b/tests/Integration/UseCases/ShowApplicationConfirmation/FakeShowApplicationConfirmationPresenter.php
@@ -15,17 +15,19 @@ class FakeShowApplicationConfirmationPresenter implements ShowApplicationConfirm
 	 * @var array<string, mixed>
 	 */
 	private array $paymentData;
+	private string $tracking;
 	private bool $anonymizedResponseWasShown = false;
 	private bool $accessViolationWasShown = false;
 	private string $shownTechnicalError;
 
-	public function presentConfirmation( MembershipApplication $application, array $paymentData ): void {
+	public function presentConfirmation( MembershipApplication $application, array $paymentData, string $tracking ): void {
 		if ( $this->application !== null ) {
 			throw new RuntimeException( 'Presenter should only be invoked once' );
 		}
 
 		$this->application = $application;
 		$this->paymentData = $paymentData;
+		$this->tracking = $tracking;
 	}
 
 	public function getShownApplication(): ?MembershipApplication {
@@ -37,6 +39,10 @@ class FakeShowApplicationConfirmationPresenter implements ShowApplicationConfirm
 	 */
 	public function getShownPaymentData(): array {
 		return $this->paymentData;
+	}
+
+	public function getShownTracking(): string {
+		return $this->tracking;
 	}
 
 	public function presentApplicationWasAnonymized(): void {

--- a/tests/Integration/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCaseTest.php
+++ b/tests/Integration/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCaseTest.php
@@ -11,6 +11,7 @@ use WMDE\Fundraising\MembershipContext\Tests\Fixtures\ValidMembershipApplication
 use WMDE\Fundraising\MembershipContext\Tests\TestDoubles\FailingAuthorizationChecker;
 use WMDE\Fundraising\MembershipContext\Tests\TestDoubles\FakeMembershipRepository;
 use WMDE\Fundraising\MembershipContext\Tests\TestDoubles\SucceedingAuthorizationChecker;
+use WMDE\Fundraising\MembershipContext\Tracking\ApplicationPiwikTracker;
 use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\ShowAppConfirmationRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\ShowApplicationConfirmationUseCase;
 use WMDE\Fundraising\PaymentContext\UseCases\GetPayment\GetPaymentUseCase;
@@ -23,6 +24,8 @@ class ShowApplicationConfirmationUseCaseTest extends TestCase {
 		'anything' => 'can',
 		'go' => 'here',
 	];
+
+	private const TRACKING = 'campaign/keyword';
 
 	private FakeShowApplicationConfirmationPresenter $presenter;
 
@@ -47,11 +50,15 @@ class ShowApplicationConfirmationUseCaseTest extends TestCase {
 		$getPaymentUseCase = $this->createStub( GetPaymentUseCase::class );
 		$getPaymentUseCase->method( 'getPaymentDataArray' )->willReturn( self::PAYMENT_DATA );
 
+		$tracking = $this->createMock( ApplicationPiwikTracker::class );
+		$tracking->method( 'getApplicationTracking' )->willReturn( self::TRACKING );
+
 		return new ShowApplicationConfirmationUseCase(
 			$this->presenter,
 			$this->authorizer,
 			$this->repository,
-			$getPaymentUseCase
+			$getPaymentUseCase,
+			$tracking
 		);
 	}
 
@@ -64,6 +71,11 @@ class ShowApplicationConfirmationUseCaseTest extends TestCase {
 		$this->assertSame(
 			self::PAYMENT_DATA,
 			$this->presenter->getShownPaymentData()
+		);
+
+		$this->assertSame(
+			self::TRACKING,
+			$this->presenter->getShownTracking()
 		);
 	}
 


### PR DESCRIPTION
We store the tracking as a string value in the request table
with no way to access it. This adds a method to the Piwik
tracker, and passes the tracking string to presenter interface.

Ticket: https://phabricator.wikimedia.org/T381958