### PR TITLE
Allow exported memberships to be fetched

### DIFF
--- a/src/DataAccess/DoctrineMembershipRepository.php
+++ b/src/DataAccess/DoctrineMembershipRepository.php
@@ -54,6 +54,11 @@ class DoctrineMembershipRepository implements MembershipRepository {
 		);
 	}
 
+	public function getMembershipApplicationById( int $id ): ?MembershipApplication {
+		$application = $this->table->getApplicationOrNullById( $id );
+		return $application === null ? null : $this->convertMembershipApplication( $application );
+	}
+
 	public function getUnexportedMembershipApplicationById( int $id ): ?MembershipApplication {
 		$application = $this->table->getApplicationOrNullById( $id );
 
@@ -65,6 +70,10 @@ class DoctrineMembershipRepository implements MembershipRepository {
 			throw new ApplicationAnonymizedException();
 		}
 
+		return $this->convertMembershipApplication( $application );
+	}
+
+	private function convertMembershipApplication( DoctrineApplication $application ): MembershipApplication {
 		$converter = new LegacyToDomainConverter();
 		return $converter->createFromLegacyObject( $application );
 	}

--- a/src/Domain/Repositories/MembershipRepository.php
+++ b/src/Domain/Repositories/MembershipRepository.php
@@ -13,12 +13,12 @@ interface MembershipRepository {
 	 */
 	public function storeApplication( MembershipApplication $application ): void;
 
+	public function getMembershipApplicationById( int $id ): ?MembershipApplication;
+
 	/**
-	 * Get a MembershipApplication domain object.
+	 * Get an un-exported MembershipApplication domain object.
 	 *
 	 * Will throw a {@see ApplicationAnonymizedException} when the membership application has been anonymized.
-	 * For most of the use cases this is desired behavior. If you ever need to read an anonymized membership application,
-	 * add a new method to the interface.
 	 *
 	 * @param int $id
 	 *

--- a/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationPresenter.php
+++ b/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationPresenter.php
@@ -18,8 +18,6 @@ interface ShowApplicationConfirmationPresenter {
 	 */
 	public function presentConfirmation( MembershipApplication $application, array $paymentData, MembershipTracking $tracking ): void;
 
-	public function presentApplicationWasAnonymized(): void;
-
 	public function presentAccessViolation(): void;
 
 	public function presentTechnicalError( string $message ): void;

--- a/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCase.php
+++ b/src/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCase.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation;
 
 use WMDE\Fundraising\MembershipContext\Authorization\MembershipAuthorizationChecker;
-use WMDE\Fundraising\MembershipContext\Domain\Repositories\ApplicationAnonymizedException;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\GetMembershipApplicationException;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\MembershipRepository;
 use WMDE\Fundraising\MembershipContext\Tracking\MembershipTrackingRepository;
@@ -29,7 +28,7 @@ class ShowApplicationConfirmationUseCase {
 		}
 
 		try {
-			$application = $this->repository->getUnexportedMembershipApplicationById( $request->getApplicationId() );
+			$application = $this->repository->getMembershipApplicationById( $request->getApplicationId() );
 			$tracking = $this->piwikTracker->getTracking( $request->getApplicationId() );
 
 			// This is here to make phpstan happy, the authorizer already checks for non-existing membership applications
@@ -39,9 +38,6 @@ class ShowApplicationConfirmationUseCase {
 			}
 
 			$paymentData = $this->getPaymentUseCase->getPaymentDataArray( $application->getPaymentId() );
-		} catch ( ApplicationAnonymizedException $ex ) {
-			$this->presenter->presentApplicationWasAnonymized();
-			return;
 		} catch ( GetMembershipApplicationException $ex ) {
 			$this->presenter->presentTechnicalError( 'A database error occurred' );
 			return;

--- a/tests/Integration/UseCases/ShowApplicationConfirmation/FakeShowApplicationConfirmationPresenter.php
+++ b/tests/Integration/UseCases/ShowApplicationConfirmation/FakeShowApplicationConfirmationPresenter.php
@@ -46,10 +46,6 @@ class FakeShowApplicationConfirmationPresenter implements ShowApplicationConfirm
 		return $this->tracking->__toString();
 	}
 
-	public function presentApplicationWasAnonymized(): void {
-		$this->anonymizedResponseWasShown = true;
-	}
-
 	public function anonymizedResponseWasShown(): bool {
 		return $this->anonymizedResponseWasShown;
 	}

--- a/tests/Integration/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCaseTest.php
+++ b/tests/Integration/UseCases/ShowApplicationConfirmation/ShowApplicationConfirmationUseCaseTest.php
@@ -84,14 +84,6 @@ class ShowApplicationConfirmationUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testWhenRepositoryThrowsAnonymizedException_anonymizedMessageIsPresented(): void {
-		$this->repository->throwAnonymizedOnRead();
-
-		$this->invokeUseCaseWithCorrectRequestModel();
-
-		$this->assertTrue( $this->presenter->anonymizedResponseWasShown() );
-	}
-
 	public function testWhenAuthorizerReturnsFalse_accessViolationIsPresented(): void {
 		$this->authorizer = new FailingAuthorizationChecker();
 

--- a/tests/TestDoubles/FakeMembershipRepository.php
+++ b/tests/TestDoubles/FakeMembershipRepository.php
@@ -69,4 +69,15 @@ class FakeMembershipRepository implements MembershipRepository {
 		return null;
 	}
 
+	public function getMembershipApplicationById( int $id ): ?MembershipApplication {
+		if ( $this->throwOnRead ) {
+			throw new GetMembershipApplicationException();
+		}
+
+		if ( array_key_exists( $id, $this->applications ) ) {
+			return clone $this->applications[$id];
+		}
+
+		return null;
+	}
 }

--- a/tests/TestDoubles/InMemoryMembershipRepository.php
+++ b/tests/TestDoubles/InMemoryMembershipRepository.php
@@ -5,9 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\MembershipContext\Tests\TestDoubles;
 
 use WMDE\Fundraising\MembershipContext\Domain\Model\MembershipApplication;
-use WMDE\Fundraising\MembershipContext\Domain\Repositories\GetMembershipApplicationException;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\MembershipRepository;
-use WMDE\Fundraising\MembershipContext\Domain\Repositories\StoreMembershipApplicationException;
 
 class InMemoryMembershipRepository implements MembershipRepository {
 
@@ -16,23 +14,15 @@ class InMemoryMembershipRepository implements MembershipRepository {
 	 */
 	private array $applications = [];
 
-	/**
-	 * @param MembershipApplication $application
-	 *
-	 * @throws StoreMembershipApplicationException
-	 */
 	public function storeApplication( MembershipApplication $application ): void {
 		$this->applications[$application->getId()] = $application;
 	}
 
-	/**
-	 * @param int $id
-	 *
-	 * @return MembershipApplication|null
-	 * @throws GetMembershipApplicationException
-	 */
-	public function getUnexportedMembershipApplicationById( int $id ): ?MembershipApplication {
+	public function getMembershipApplicationById( int $id ): ?MembershipApplication {
 		return array_key_exists( $id, $this->applications ) ? $this->applications[$id] : null;
 	}
 
+	public function getUnexportedMembershipApplicationById( int $id ): ?MembershipApplication {
+		return $this->getMembershipApplicationById( $id );
+	}
 }


### PR DESCRIPTION
The membership confirmation page is now able to handle
anonymised membership applications so we no longer need
to show a separate page.

This adds a method to allow fetching an exported
membership to the MembershipRepository and calls that
in the ShowApplicationConfirmationUseCase.

It also adds/adjusts tests for the above.

Ticket: https://phabricator.wikimedia.org/T316201