### PR TITLE
Add backup class for personal data

### DIFF
--- a/src/DataAccess/Backup/DatabaseBackupClient.php
+++ b/src/DataAccess/Backup/DatabaseBackupClient.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\DataAccess\Backup;
+
+/**
+ * The backup client is responsible for getting the data out of the database and writing it somewhere.
+ *
+ * The membership bounded context only exposes the interface, the actual implementation
+ * (e.g. with `shell_exec` calling `mysqldump`, etc.) is in the Fundraising Operation Center
+ */
+interface DatabaseBackupClient {
+	/**
+	 * @param TableBackupConfiguration ...$tableBackupConfigurations At least one table configuration.
+	 *          The client implementation can decide to write all table output into one file or to split
+	 *          them into individual files.
+	 * @return void
+	 */
+	public function backupMembershipTables( TableBackupConfiguration ...$tableBackupConfigurations ): void;
+}

--- a/src/DataAccess/Backup/PersonalDataBackup.php
+++ b/src/DataAccess/Backup/PersonalDataBackup.php
@@ -1,0 +1,37 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\DataAccess\Backup;
+
+use Doctrine\ORM\EntityManager;
+use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\MembershipApplication;
+
+class PersonalDataBackup {
+
+	public function __construct(
+		private readonly DatabaseBackupClient $backupClient,
+		private readonly EntityManager $entityManager
+	) {
+	}
+
+	public function doBackup( \DateTimeImmutable $backupTime ): int {
+		$this->backupClient->backupMembershipTables(
+			new TableBackupConfiguration( 'request', 'backup IS NULL' )
+		);
+
+		$qb = $this->entityManager->createQueryBuilder();
+		$qb->update( MembershipApplication::class, 'm' )
+			->set( 'm.backup', ':backupTime' )
+			->where( 'm.backup IS NULL ' )
+			->setParameter( 'backupTime', $backupTime );
+
+		/** @var int $affectedRows */
+		$affectedRows = $qb->getQuery()->execute();
+
+		// Clear all lingering entities, they don't get changed by the update query
+		// See https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/dql-doctrine-query-language.html#update-queries
+		$this->entityManager->clear();
+
+		return $affectedRows;
+	}
+}

--- a/src/DataAccess/Backup/TableBackupConfiguration.php
+++ b/src/DataAccess/Backup/TableBackupConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\DataAccess\Backup;
+
+class TableBackupConfiguration {
+
+	/**
+	 * @param string $tableName A database table name
+	 * @param string $conditions SQL conditions to select the data that should be backed up from the table. Can be empty for "all data".
+	 */
+	public function __construct(
+		public readonly string $tableName,
+		public readonly string $conditions
+	) {
+	}
+}

--- a/tests/Fixtures/ValidMembershipApplication.php
+++ b/tests/Fixtures/ValidMembershipApplication.php
@@ -204,8 +204,8 @@ class ValidMembershipApplication {
 		return $application;
 	}
 
-	public static function newDoctrineCompanyEntity(): DoctrineMembershipApplication {
-		$application = self::createDoctrineApplicationWithoutApplicantName();
+	public static function newDoctrineCompanyEntity( int $id = self::DEFAULT_ID ): DoctrineMembershipApplication {
+		$application = self::createDoctrineApplicationWithoutApplicantName( $id );
 
 		$application->setCompany( self::APPLICANT_COMPANY_NAME );
 		$application->setApplicantTitle( '' );
@@ -217,9 +217,9 @@ class ValidMembershipApplication {
 		return $application;
 	}
 
-	public static function newAnonymizedDoctrineEntity(): DoctrineMembershipApplication {
-		$application = self::newDoctrineEntity();
-		$application->setBackup( new DateTime() );
+	public static function newAnonymizedDoctrineEntity( int $id = self::DEFAULT_ID, ?DateTime $backupTime = null ): DoctrineMembershipApplication {
+		$application = self::newDoctrineEntity( $id );
+		$application->setBackup( $backupTime ?? new DateTime() );
 		return $application;
 	}
 

--- a/tests/Integration/DataAccess/PersonalDataBackupTest.php
+++ b/tests/Integration/DataAccess/PersonalDataBackupTest.php
@@ -1,0 +1,88 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\Tests\Integration\DataAccess;
+
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\MembershipContext\DataAccess\Backup\DatabaseBackupClient;
+use WMDE\Fundraising\MembershipContext\DataAccess\Backup\PersonalDataBackup;
+use WMDE\Fundraising\MembershipContext\DataAccess\Backup\TableBackupConfiguration;
+use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\MembershipApplication;
+use WMDE\Fundraising\MembershipContext\Tests\Fixtures\ValidMembershipApplication;
+use WMDE\Fundraising\MembershipContext\Tests\TestDoubles\DatabaseBackupClientSpy;
+use WMDE\Fundraising\MembershipContext\Tests\TestEnvironment;
+
+#[CoversClass( PersonalDataBackup::class )]
+class PersonalDataBackupTest extends TestCase {
+	private const string BACKUP_TIME = '2025-04-03 1:02:00';
+
+	public function testBackupClientIsCalledWithMembershipTablesAndConditions(): void {
+		$backupClientSpy = new DatabaseBackupClientSpy();
+		$personalBackup = $this->givenPersonalBackup( backupClient: $backupClientSpy );
+
+		$personalBackup->doBackup( $this->givenBackupTime() );
+
+		$backupConfigurations = $backupClientSpy->getTableBackupConfigurations();
+		$this->assertCount( 1, $backupConfigurations );
+		$this->assertEquals(
+			new TableBackupConfiguration( 'request', 'backup IS NULL' ),
+			$backupConfigurations[0]
+		);
+	}
+
+	public function testUnmarkedMembershipsGetMarkedAsBackedUp(): void {
+		$factory = TestEnvironment::newInstance()->getFactory();
+		$entityManager = $factory->getEntityManager();
+		$this->givenMemberships( $entityManager );
+		$personalBackup = $this->givenPersonalBackup( entityManager: $entityManager );
+
+		$personalBackup->doBackup( $this->givenBackupTime() );
+
+		$qb = $entityManager->createQueryBuilder();
+		$qb->select( 'COUNT( m ) as updated_memberships' )
+			->from( MembershipApplication::class, 'm' )
+			->where( 'm.backup = :backupTime' )
+			->setParameter( 'backupTime', $this->givenBackupTime() );
+		$this->assertSame( [ [ 'updated_memberships' => 4 ] ], $qb->getQuery()->getScalarResult() );
+	}
+
+	public function testDoBackupReturnsNumberOfAffectedMemberships(): void {
+		$factory = TestEnvironment::newInstance()->getFactory();
+		$entityManager = $factory->getEntityManager();
+		$this->givenMemberships( $entityManager );
+		$personalBackup = $this->givenPersonalBackup( entityManager: $entityManager );
+
+		$affectedDonations = $personalBackup->doBackup( $this->givenBackupTime() );
+
+		$this->assertSame( 4, $affectedDonations );
+	}
+
+	private function givenPersonalBackup( ?DatabaseBackupClientSpy $backupClient = null, ?EntityManager $entityManager = null ): PersonalDataBackup {
+		if ( $backupClient === null ) {
+			$backupClient = $this->createStub( DatabaseBackupClient::class );
+		}
+		if ( $entityManager === null ) {
+			$factory = TestEnvironment::newInstance()->getFactory();
+			$entityManager = $factory->getEntityManager();
+		}
+		return new PersonalDataBackup( $backupClient, $entityManager );
+	}
+
+	private function givenBackupTime(): \DateTimeImmutable {
+		return new \DateTimeImmutable( self::BACKUP_TIME );
+	}
+
+	private function givenMemberships( EntityManager $entityManager ): void {
+		$entityManager->persist( ValidMembershipApplication::newDoctrineEntity( 1 ) );
+		$entityManager->persist( ValidMembershipApplication::newDoctrineEntity( 2 ) );
+		$entityManager->persist( ValidMembershipApplication::newDoctrineCompanyEntity( 3 ) );
+		$entityManager->persist( ValidMembershipApplication::newDoctrineCompanyEntity( 4 ) );
+
+		$entityManager->persist( ValidMembershipApplication::newAnonymizedDoctrineEntity( 10, new \DateTime( '2025-03-03 0:00:00' ) ) );
+		$entityManager->persist( ValidMembershipApplication::newAnonymizedDoctrineEntity( 11, new \DateTime() ) );
+
+		$entityManager->flush();
+	}
+}

--- a/tests/TestDoubles/DatabaseBackupClientSpy.php
+++ b/tests/TestDoubles/DatabaseBackupClientSpy.php
@@ -1,0 +1,32 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\Tests\TestDoubles;
+
+use WMDE\Fundraising\MembershipContext\DataAccess\Backup\DatabaseBackupClient;
+use WMDE\Fundraising\MembershipContext\DataAccess\Backup\TableBackupConfiguration;
+
+class DatabaseBackupClientSpy implements DatabaseBackupClient {
+	/**
+	 * @var TableBackupConfiguration[]
+	 */
+	private ?array $tableBackupConfigurations = null;
+
+	public function backupMembershipTables( TableBackupConfiguration ...$backupConfigurations ): void {
+		if ( $this->tableBackupConfigurations !== null ) {
+			throw new \LogicException( "backupTable must only be called once!" );
+		}
+		$this->tableBackupConfigurations = $backupConfigurations;
+	}
+
+	/**
+	 * @return TableBackupConfiguration[]
+	 */
+	public function getTableBackupConfigurations(): array {
+		if ( $this->tableBackupConfigurations === null ) {
+			throw new \LogicException( 'backupTable was never called!' );
+		}
+		return $this->tableBackupConfigurations;
+	}
+
+}


### PR DESCRIPTION
Before scrubbing the personal data from the database, we want to write
it to an encrypted short-term storage, to be able to restore it in cases
when scrubbing goes awry.

This code introduces a class, PersonalDataBackup that calls a
DatabaseBackupClient interface for writing the data and then marks the
exported data with a date. The actual implementation of the
DatabaseBackupClient will be done by the Fundraising Operation Center.

Ticket: https://phabricator.wikimedia.org/T372790
