### PR TITLE
Deprecate auth tokens in data blob

### DIFF
--- a/src/DataAccess/DoctrineEntities/MembershipApplication.php
+++ b/src/DataAccess/DoctrineEntities/MembershipApplication.php
@@ -629,9 +629,10 @@ class MembershipApplication {
 	}
 
 	/**
-	 * WARNING: updates made to the return value will not be reflected in the Donation state.
-	 * Similarly, updates to the Donation state will not propagate to the returned object.
-	 * To update the Donation state, explicitly call @see setDataObject.
+	 * WARNING: updates made to the return value will not be reflected in the Membership state.
+	 * Similarly, updates to the Membership state will not propagate to the returned object.
+	 * To update the Membership state, explicitly call @see setDataObject.
+	 * @deprecated The access tokens have been removed from the blob. You should set this information using the AuthenticationToken entity in the Application or Op Center
 	 */
 	public function getDataObject(): MembershipApplicationData {
 		$dataArray = $this->getDecodedData();
@@ -645,6 +646,9 @@ class MembershipApplication {
 		return $data;
 	}
 
+	/**
+	 * @deprecated The access tokens have been removed from the blob. You should set this information using the AuthenticationToken entity in the Application or Op Center
+	 */
 	public function setDataObject( MembershipApplicationData $data ): void {
 		$dataArray = array_merge(
 			$this->getDecodedData(),
@@ -666,6 +670,7 @@ class MembershipApplication {
 
 	/**
 	 * @param callable $modificationFunction Takes a modifiable MembershipApplicationData parameter
+	 * @deprecated The access tokens have been removed from the blob. You should set this information using the AuthenticationToken entity in the Application or Op Center
 	 */
 	public function modifyDataObject( callable $modificationFunction ): void {
 		$dataObject = $this->getDataObject();

--- a/src/DataAccess/DoctrineMembershipAuthorizationChecker.php
+++ b/src/DataAccess/DoctrineMembershipAuthorizationChecker.php
@@ -11,8 +11,8 @@ use WMDE\Fundraising\MembershipContext\DataAccess\Internal\DoctrineApplicationTa
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\GetMembershipApplicationException;
 
 /**
- * This is only for checking legacy donation authorizations.
- *  New donations should use an implementation of MembershipAuthorizationChecker that uses tokens stored outside the bounded context.
+ * This is only for checking legacy membership authorizations.
+ * @deprecated New memberships should use an implementation of MembershipAuthorizationChecker that uses tokens stored outside the bounded context.
  */
 class DoctrineMembershipAuthorizationChecker implements MembershipAuthorizationChecker {
 

--- a/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
+++ b/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\Collection;
 use Traversable;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\MembershipApplication as DoctrineApplication;
-use WMDE\Fundraising\MembershipContext\DataAccess\MembershipApplicationData;
 use WMDE\Fundraising\MembershipContext\Domain\Model\Applicant;
 use WMDE\Fundraising\MembershipContext\Domain\Model\Incentive;
 use WMDE\Fundraising\MembershipContext\Domain\Model\MembershipApplication;
@@ -39,7 +38,6 @@ class DomainToLegacyConverter {
 		);
 
 		$doctrineStatus = $this->getDoctrineStatus( $application );
-		$this->preserveDoctrineStatus( $doctrineApplication, $doctrineStatus );
 		$doctrineApplication->setStatus( $doctrineStatus );
 	}
 
@@ -154,13 +152,5 @@ class DomainToLegacyConverter {
 		}
 
 		return DoctrineApplication::STATUS_NEUTRAL;
-	}
-
-	private function preserveDoctrineStatus( DoctrineApplication $doctrineApplication, int $doctrineStatus ): void {
-		if ( $doctrineStatus < DoctrineApplication::STATUS_CONFIRMED ) {
-			$doctrineApplication->modifyDataObject( static function ( MembershipApplicationData $data ): void {
-				$data->setPreservedStatus( DoctrineApplication::STATUS_CONFIRMED );
-			} );
-		}
 	}
 }

--- a/src/DataAccess/MembershipApplicationData.php
+++ b/src/DataAccess/MembershipApplicationData.php
@@ -4,6 +4,10 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\DataAccess;
 
+/**
+ * @deprecated The access tokens are an HTTP layer detail that does not belong in the domain.
+ *              You should access this information using the AuthenticationToken entity in the Application or Op Center.
+ */
 class MembershipApplicationData {
 
 	private ?string $accessToken = null;

--- a/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
@@ -196,16 +196,6 @@ class DoctrineMembershipApplicationRepositoryTest extends TestCase {
 		$this->assertSame( 'chuck.norris@always.win', $doctrineApplication->getApplicantEmailAddress() );
 	}
 
-	public function testGivenDoctrineApplicationWithCancelledFlag_initialStatusIsPreserved(): void {
-		$application = ValidMembershipApplication::newDomainEntity();
-		$application->cancel();
-
-		$this->givenApplicationRepository()->storeApplication( $application );
-		$doctrineApplication = $this->getApplicationFromDatabase( $application->getId() );
-
-		$this->assertSame( DoctrineApplication::STATUS_CONFIRMED, $doctrineApplication->getDataObject()->getPreservedStatus() );
-	}
-
 	public function testGivenCompanyApplication_companyNameIsPersisted(): void {
 		$this->givenApplicationRepository()->storeApplication( ValidMembershipApplication::newCompanyApplication() );
 

--- a/tests/Integration/DataAccess/DoctrineMembershipRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipRepositoryTest.php
@@ -24,7 +24,7 @@ use WMDE\Fundraising\MembershipContext\Tests\TestEnvironment;
 use WMDE\Fundraising\PaymentContext\UseCases\GetPayment\GetPaymentUseCase;
 
 #[CoversClass( DoctrineMembershipRepository::class )]
-class DoctrineMembershipApplicationRepositoryTest extends TestCase {
+class DoctrineMembershipRepositoryTest extends TestCase {
 
 	use ThrowingEntityManagerTrait;
 

--- a/tests/Unit/DoctrineEntities/MembershipApplicationTest.php
+++ b/tests/Unit/DoctrineEntities/MembershipApplicationTest.php
@@ -96,6 +96,9 @@ class MembershipApplicationTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @deprecated Remove when removing {@see MembershipApplication::modifyDataObject}
+	 */
 	public function testWhenModifyingTheDataObject_modificationsAreReflected(): void {
 		$application = new MembershipApplication();
 		$application->encodeAndSetData( [


### PR DESCRIPTION
- Deprecate `MembershipApplicationData` class
- Deprecate accessors of `MembershipApplicationData`
- Deprecate `DoctrineMembershipAuthorizationChecker` - that's now done
  with different classes in the applications.
- Remove `preserveDoctrineStatus` method from `DomainToLegacyConverter`.
  This was used to preserve the initial membership status
  (confirmed/unconfirmed) when restoring canceled memberships. With
  the introduction of the payment bounded context, this is now obsolete,
  because the restore membership status now fully depends on the payment
  state (see `RestoreMembershipApplicationUseCase`).

Ticket: https://phabricator.wikimedia.org/T390844
