### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This marks the default owner group of all files in this repository
+*	@wmde/funtech-core


### PR DESCRIPTION
- all files in this repository belong to the funtech-core team
- this file is needed because dependabot is deprecating the "reviewers" setting

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/