### PR TITLE
Remove deprecated `reviewers` config item

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    reviewers:
-      - "wmde/funtech-core"
     groups:
       patch-updates:
         update-types:


### PR DESCRIPTION
- the config item will be removed on May 27, 2025 https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/