### PR TITLE
Add new membership fee change branch

### DIFF
--- a/src/UseCases/FeeChange/ShowFeeChangePresenter.php
+++ b/src/UseCases/FeeChange/ShowFeeChangePresenter.php
@@ -10,4 +10,6 @@ interface ShowFeeChangePresenter {
 	public function showFeeChangeError(): void;
 
 	public function showFeeChangeAlreadyFilled(): void;
+
+	public function showFeeChangeInactive(): void;
 }


### PR DESCRIPTION
When the membership fee change is inactive we need
to present the member with a message. This adds a
new presenter method and handles it in the use
case.

Ticket: https://phabricator.wikimedia.org/T415775