### PR TITLE
Implement anonymization monitoring for moderated memberships

### DIFF
--- a/src/DataAccess/DoctrineMembershipAnonymizationMonitor.php
+++ b/src/DataAccess/DoctrineMembershipAnonymizationMonitor.php
@@ -24,33 +24,39 @@ class DoctrineMembershipAnonymizationMonitor implements MembershipAnonymizationM
 		$gracePeriodDate = \DateTime::createFromImmutable( $now->sub( new \DateInterval( self::MODERATION_GRACE_PERIOD ) ) );
 
 		$queryBuilder
-			->select( "COUNT(id)" )
+			->select( 'id' )
 			->from( 'request', 'r' )
 			// only look for membership applications that got flagged for moderation
-			->innerJoin(
+			/*->innerJoin(
 				fromAlias: 'r',
 				join: 'memberships_moderation_reasons',
-				alias: 'mmr',
-				condition: 'r.id = mmr.membership_id'
-			)
+				alias: 'mmr'
+			)*/
 
 			// only include them if they still contain personal data
-			->where(
+		/*->where(
 				$queryBuilder->expr()->or(
 					$queryBuilder->expr()->and(
 						$queryBuilder->expr()->isNotNull( 'r.name' ),
-						$queryBuilder->expr()->neq( 'r,name', '' )
+						$queryBuilder->expr()->neq( 'r.name', '' )
 					),
 					$queryBuilder->expr()->and(
 						$queryBuilder->expr()->isNotNull( 'r.email' ),
-						$queryBuilder->expr()->neq( 'r,email', '' )
+						$queryBuilder->expr()->neq( 'r.email', '' )
 					)
-			) )
-			// only look for older "seemingly abandoned" entries older than the grace period
-			->andWhere( 'r.timestamp <= :moderationGracePeriodDate' )
-			->setParameter( 'moderationGracePeriodDate', $gracePeriodDate );
+			) ); */
 
-		$count = $queryBuilder->executeQuery()->fetchOne();
+			->where(
+					$queryBuilder->expr()->and(
+						$queryBuilder->expr()->isNotNull( 'r.name' ),
+						$queryBuilder->expr()->neq( 'r.name', '' )
+					)
+				);
+			// only look for older "seemingly abandoned" entries older than the grace period
+			//->andWhere( 'r.timestamp <= :moderationGracePeriodDate' );
+			//->setParameter( 'moderationGracePeriodDate', $gracePeriodDate );
+
+		$count = $queryBuilder->executeQuery()->rowCount();
 
 		if ( !is_scalar( $count ) ) {
 			return -1;

--- a/src/DataAccess/DoctrineMembershipAnonymizationMonitor.php
+++ b/src/DataAccess/DoctrineMembershipAnonymizationMonitor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\MembershipContext\DataAccess;
+
+use Doctrine\DBAL\Connection;
+use WMDE\Fundraising\MembershipContext\Domain\MembershipAnonymizationMonitor;
+
+class DoctrineMembershipAnonymizationMonitor implements MembershipAnonymizationMonitor {
+
+	private const string MODERATION_GRACE_PERIOD = 'P1M';
+
+	private Connection $conn;
+
+	public function __construct( Connection $conn ) {
+		$this->conn = $conn;
+	}
+
+	public function countOldAbandonedModeratedMembershipApplications(): int {
+		$queryBuilder = $this->conn->createQueryBuilder();
+
+		$now = new \DateTimeImmutable();
+		$gracePeriodDate = \DateTime::createFromImmutable( $now->sub( new \DateInterval( self::MODERATION_GRACE_PERIOD ) ) );
+
+		$queryBuilder
+			->select( "COUNT(id)" )
+			->from( 'request', 'r' )
+			// only look for membership applications that got flagged for moderation
+			->innerJoin(
+				fromAlias: 'r',
+				join: 'memberships_moderation_reasons',
+				alias: 'mmr',
+				condition: 'r.id = mmr.membership_id'
+			)
+
+			// only include them if they still contain personal data
+			->where(
+				$queryBuilder->expr()->or(
+					$queryBuilder->expr()->and(
+						$queryBuilder->expr()->isNotNull( 'r.name' ),
+						$queryBuilder->expr()->neq( 'r,name', '' )
+					),
+					$queryBuilder->expr()->and(
+						$queryBuilder->expr()->isNotNull( 'r.email' ),
+						$queryBuilder->expr()->neq( 'r,email', '' )
+					)
+			) )
+			// only look for older "seemingly abandoned" entries older than the grace period
+			->andWhere( 'r.timestamp <= :moderationGracePeriodDate' )
+			->setParameter( 'moderationGracePeriodDate', $gracePeriodDate );
+
+		$count = $queryBuilder->executeQuery()->fetchOne();
+
+		if ( !is_scalar( $count ) ) {
+			return -1;
+		}
+		return intval( $count );
+	}
+
+}

--- a/src/DataAccess/DoctrineMembershipAnonymizationMonitor.php
+++ b/src/DataAccess/DoctrineMembershipAnonymizationMonitor.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\MembershipContext\DataAccess;
 
 use Doctrine\DBAL\Connection;
+use WMDE\Clock\Clock;
 use WMDE\Fundraising\MembershipContext\Domain\MembershipAnonymizationMonitor;
 
 class DoctrineMembershipAnonymizationMonitor implements MembershipAnonymizationMonitor {
@@ -12,51 +13,25 @@ class DoctrineMembershipAnonymizationMonitor implements MembershipAnonymizationM
 	private const string MODERATION_GRACE_PERIOD = 'P1M';
 
 	private Connection $conn;
+	private Clock $clock;
 
-	public function __construct( Connection $conn ) {
+	public function __construct( Connection $conn, Clock $clock ) {
 		$this->conn = $conn;
+		$this->clock = $clock;
 	}
 
 	public function countOldAbandonedModeratedMembershipApplications(): int {
-		$queryBuilder = $this->conn->createQueryBuilder();
-
-		$now = new \DateTimeImmutable();
+		$now = $this->clock->now();
 		$gracePeriodDate = \DateTime::createFromImmutable( $now->sub( new \DateInterval( self::MODERATION_GRACE_PERIOD ) ) );
 
-		$queryBuilder
-			->select( 'id' )
-			->from( 'request', 'r' )
-			// only look for membership applications that got flagged for moderation
-			/*->innerJoin(
-				fromAlias: 'r',
-				join: 'memberships_moderation_reasons',
-				alias: 'mmr'
-			)*/
+		$sqlQuery = "SELECT COUNT(id) as count FROM request r INNER JOIN memberships_moderation_reasons mmr ON r.id=mmr.membership_id " .
+			"WHERE ( ( r.name is not null AND r.name!='' ) OR ( r.email is not NULL AND r.email!='' ) ) AND r.timestamp < :gracePeriodDate;";
+		$queryResult = $this->conn->executeQuery(
+			sql: $sqlQuery,
+			params: [ 'gracePeriodDate' => $gracePeriodDate->format( 'Y-m-d H:i:s' ) ]
+		);
 
-			// only include them if they still contain personal data
-		/*->where(
-				$queryBuilder->expr()->or(
-					$queryBuilder->expr()->and(
-						$queryBuilder->expr()->isNotNull( 'r.name' ),
-						$queryBuilder->expr()->neq( 'r.name', '' )
-					),
-					$queryBuilder->expr()->and(
-						$queryBuilder->expr()->isNotNull( 'r.email' ),
-						$queryBuilder->expr()->neq( 'r.email', '' )
-					)
-			) ); */
-
-			->where(
-					$queryBuilder->expr()->and(
-						$queryBuilder->expr()->isNotNull( 'r.name' ),
-						$queryBuilder->expr()->neq( 'r.name', '' )
-					)
-				);
-			// only look for older "seemingly abandoned" entries older than the grace period
-			//->andWhere( 'r.timestamp <= :moderationGracePeriodDate' );
-			//->setParameter( 'moderationGracePeriodDate', $gracePeriodDate );
-
-		$count = $queryBuilder->executeQuery()->rowCount();
+		$count = $queryResult->fetchOne();
 
 		if ( !is_scalar( $count ) ) {
 			return -1;

--- a/src/Domain/MembershipAnonymizationMonitor.php
+++ b/src/Domain/MembershipAnonymizationMonitor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\MembershipContext\Domain;
+
+/**
+ * This class contains methods to monitor the amount of older membership applications in the database which still
+ * contain private data.
+ * We use them to check whether our private data scrubbing processes work correctly.
+ */
+interface MembershipAnonymizationMonitor {
+
+	/**
+	 * @return int amount of old membership applications that are still marked
+	 * as moderated in the database and need to get their status resolved. This is needed to scrub them
+	 */
+	public function countOldAbandonedModeratedMembershipApplications(): int;
+
+}

--- a/tests/Integration/DataAccess/DoctrineMembershipAnonymizationMonitorTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipAnonymizationMonitorTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\MembershipContext\Tests\Integration\DataAccess;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\MembershipApplication;
+use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineMembershipAnonymizationMonitor;
+use WMDE\Fundraising\MembershipContext\Tests\TestEnvironment;
+
+#[CoversClass( DoctrineMembershipAnonymizationMonitor::class )]
+class DoctrineMembershipAnonymizationMonitorTest extends TestCase {
+
+	private Connection $conn;
+	private DoctrineMembershipAnonymizationMonitor $monitor;
+
+	private \DateTime $now;
+
+	private \DateTime $defaultExportTime;
+	private const int MEMBERSHIP_ID = 1;
+	private const int ANOTHER_MEMBERSHIP_ID = 2;
+
+	public function setUp(): void {
+		$this->conn = TestEnvironment::newInstance()->getFactory()->getConnection();
+		$this->now = new \DateTime();
+		$this->monitor = new DoctrineMembershipAnonymizationMonitor( $this->conn );
+	}
+
+	public function testCountOldAbandonedModeratedMembershipApplications_ReturnsMinusOneOnError(): void {
+		$throwingMonitor = new DoctrineMembershipAnonymizationMonitor( $this->givenThrowingDatabaseConnection() );
+
+		$this->assertEquals( -1, $throwingMonitor->countOldAbandonedModeratedMembershipApplications() );
+	}
+
+	public function testCountOldAbandonedModeratedMembershipApplications_ExcludesRecentEntries(): void {
+		// TODO
+		// create older moderated membership
+		$this->insertModeratedMembership(
+			id: 1,
+			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+		);
+		// create recent moderated membership
+		$this->insertModeratedMembership(
+			id: 2,
+			creationTime: $this->now
+		);
+		$this->assertSame( 1, $this->monitor->countOldAbandonedModeratedMembershipApplications() );
+	}
+
+	public function testCountOldAbandonedModeratedMembershipApplications_OnlyIncludesEntriesStillContainingPersonalData(): void {
+		// TODO
+		// create older moderated membership with personal data
+		$this->insertModeratedMembership(
+			id: 3,
+			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+		);
+		// create older moderated membership that got already exported and scrubbed (status, ...)
+		$this->newScrubbedMembershipRecord(
+			id: 4,
+			creationDate: $this->now->sub( new \DateInterval( 'P1Y' ) )
+		);
+		$this->assertMembershipIsAnonymized( 4 );
+		// expect report to contain 1
+		$this->assertSame( 1, $this->monitor->countOldAbandonedModeratedMembershipApplications() );
+	}
+
+	public function testCountOldAbandonedModeratedMembershipApplications_OnlyIncludesModeratedEntries(): void {
+		// TODO
+		// create normal older membership
+		$this->insertNonModeratedMembership(
+			id: 5,
+			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+		);
+		// create moderated older membership
+		$this->insertModeratedMembership(
+			id: 6,
+			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+		);
+		// expect report to contain 1
+		$this->assertSame( 1, $this->monitor->countOldAbandonedModeratedMembershipApplications() );
+	}
+
+	private function givenThrowingDatabaseConnection(): Connection {
+		$queryBuilderStub = $this->createStub( QueryBuilder::class );
+		$queryBuilderStub->method( 'executeStatement' )
+			->willThrowException( new \RuntimeException( 'Database Exception, thrown by test double' ) );
+
+		return $this->createConfiguredStub(
+			Connection::class,
+			[ 'createQueryBuilder' => $queryBuilderStub ]
+		);
+	}
+
+	private function insertMembership( int $id = self::MEMBERSHIP_ID, ?\DateTime $creationDate = null ): void {
+		$this->conn->insert( 'request', $this->newMembershipRecord( $id, $creationDate ) );
+	}
+
+	private function insertDeletedMembership( int $id ): void {
+		$membership = $this->newMembershipRecord( $id );
+		$membership['status'] = MembershipApplication::STATUS_CANCELED;
+
+		$this->conn->insert( 'request', $membership );
+	}
+
+	private function insertModeratedMembership( int $id, \DateTime $creationTime ): void {
+		$membership = $this->newMembershipRecord( $id );
+		$membership['status'] = MembershipApplication::STATUS_MODERATION;
+		$membership['timestamp'] = $creationTime->format( 'Y-m-d H:i:s' );
+
+		$this->conn->insert( 'request', $membership );
+	}
+
+	private function insertNonModeratedMembership( int $id, \DateTime $creationTime ): void {
+		$membership = $this->newMembershipRecord( $id );
+		$membership['status'] = MembershipApplication::STATUS_CONFIRMED;
+		$membership['timestamp'] = $creationTime->format( 'Y-m-d H:i:s' );
+
+		$this->conn->insert( 'request', $membership );
+	}
+
+	private function insertExportedMembership( int $id, \DateTime $exportTime ): void {
+		$membership = $this->newMembershipRecord( $id );
+		$membership['export'] = $exportTime->format( 'Y-m-d H:i:s' );
+		$this->conn->insert( 'request', $membership );
+	}
+
+	/**
+	 * @param int $id
+	 * @return array<string,string|int>
+	 */
+	private function newMembershipRecord( int $id, ?\DateTime $creationDate = null ): array {
+		$nowString = $this->now->format( 'Y-m-d H:i:s' );
+		$creationString = $creationDate ? $creationDate->format( 'Y-m-d H:i:s' ) : $this->now->sub( new \DateInterval( 'P1D' ) )->format( 'Y-m-d H:i:s' );
+		return [
+			'id' => $id,
+			'email' => 'ceo@ecorp.biz',
+			'anrede' => 'Herr',
+			'titel' => '',
+			'firma' => 'E Corp',
+			'name' => 'Phillip Price',
+			'vorname' => 'Phillip',
+			'nachname' => 'Price',
+			'strasse' => '135 East 57th Street',
+			'plz' => '12345',
+			'ort' => 'New York City',
+			'dob' => '1966-03-13 13:13:13',
+			'iban' => 'DE02120300000000202051',
+			'bic' => 'BYLADEM1001',
+			'status' => MembershipApplication::STATUS_NEUTRAL,
+			'backup' => $nowString,
+			'timestamp' => $creationString,
+			'is_scrubbed' => 0
+		];
+	}
+
+	private function newScrubbedMembershipRecord( int $id, ?\DateTime $creationDate = null ): array {
+		$nowString = $this->now->format( 'Y-m-d H:i:s' );
+		$creationString = $creationDate ? $creationDate->format( 'Y-m-d H:i:s' ) : $this->now->sub( new \DateInterval( 'P1D' ) )->format( 'Y-m-d H:i:s' );
+		return [
+			'id' => $id,
+			'email' => '',
+			'anrede' => '',
+			'titel' => '',
+			'firma' => '',
+			'name' => '',
+			'vorname' => '',
+			'nachname' => '',
+			'strasse' => '',
+			'plz' => '',
+			'ort' => '',
+			'dob' => null,
+			'iban' => 'DE02120300000000202051',
+			'bic' => 'BYLADEM1001',
+			'status' => MembershipApplication::STATUS_NEUTRAL,
+			'backup' => $nowString,
+			'timestamp' => $creationString,
+			'is_scrubbed' => 1
+		];
+	}
+
+	private function assertMembershipIsAnonymized( int $membershipId ): void {
+		$result = $this->conn->executeQuery(
+			'SELECT anrede, firma, titel, name, vorname, nachname, strasse, plz, ort, email, iban, bic, dob, is_scrubbed FROM request WHERE id = :id',
+			[ 'id' => $membershipId ]
+		);
+		$row = $result->fetchAssociative();
+		$this->assertEquals( [
+			'anrede' => '',
+			'firma' => '',
+			'titel' => '',
+			'name' => '',
+			'vorname' => '',
+			'nachname' => '',
+			'strasse' => '',
+			'plz' => '',
+			'ort' => '',
+			'email' => '',
+			'iban' => '',
+			'bic' => '',
+			'dob' => null,
+			'is_scrubbed' => 1
+		], $row );
+	}
+
+	/**
+	 * @param array<string,scalar> $expectedMembership
+	 * @return void
+	 * @throws \Doctrine\DBAL\Exception
+	 */
+	private function assertMembershipIsUnAnonymized( array $expectedMembership ): void {
+		unset( $expectedMembership['backup'] );
+		$result = $this->conn->executeQuery(
+			'SELECT id, anrede, firma, titel, name, vorname, nachname, strasse, plz, ort, email, iban, bic, dob, status, timestamp, is_scrubbed FROM request WHERE id = :id',
+			[ 'id' => $expectedMembership['id'] ]
+		);
+		$row = $result->fetchAssociative();
+		$this->assertEquals( $expectedMembership, $row );
+	}
+}

--- a/tests/Integration/DataAccess/DoctrineMembershipAnonymizationMonitorTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipAnonymizationMonitorTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use WMDE\Clock\Clock;
+use WMDE\Clock\SystemClock;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\MembershipApplication;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineMembershipAnonymizationMonitor;
 use WMDE\Fundraising\MembershipContext\Tests\TestEnvironment;
@@ -18,78 +20,69 @@ class DoctrineMembershipAnonymizationMonitorTest extends TestCase {
 	private Connection $conn;
 	private DoctrineMembershipAnonymizationMonitor $monitor;
 
-	private \DateTime $now;
-
-	private \DateTime $defaultExportTime;
-	private const int MEMBERSHIP_ID = 1;
-	private const int ANOTHER_MEMBERSHIP_ID = 2;
+	private Clock $clock;
 
 	public function setUp(): void {
 		$this->conn = TestEnvironment::newInstance()->getFactory()->getConnection();
-		$this->now = new \DateTime();
-		$this->monitor = new DoctrineMembershipAnonymizationMonitor( $this->conn );
+		$this->clock = new SystemClock();
+		$this->monitor = new DoctrineMembershipAnonymizationMonitor( $this->conn, $this->clock );
 	}
 
 	public function testCountOldAbandonedModeratedMembershipApplications_ReturnsMinusOneOnError(): void {
-		$throwingMonitor = new DoctrineMembershipAnonymizationMonitor( $this->givenThrowingDatabaseConnection() );
+		$throwingMonitor = new DoctrineMembershipAnonymizationMonitor( $this->givenThrowingDatabaseConnection(), $this->clock );
 
 		$this->assertEquals( -1, $throwingMonitor->countOldAbandonedModeratedMembershipApplications() );
 	}
 
 	public function testCountOldAbandonedModeratedMembershipApplications_ExcludesRecentEntries(): void {
-		// TODO
 		// create older moderated membership
 		$this->insertModeratedMembership(
-			id: 1,
-			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+			membershipId: 1,
+			creationTime: $this->clock->now()->sub( new \DateInterval( 'P1Y' ) )
 		);
 		// create recent moderated membership
 		$this->insertModeratedMembership(
-			id: 2,
-			creationTime: $this->now
+			membershipId: 2,
+			creationTime: $this->clock->now()->sub( new \DateInterval( 'P28D' ) )
 		);
 		$this->assertSame( 1, $this->monitor->countOldAbandonedModeratedMembershipApplications() );
 	}
 
 	public function testCountOldAbandonedModeratedMembershipApplications_OnlyIncludesEntriesStillContainingPersonalData(): void {
-		// TODO
 		// create older moderated membership with personal data
 		$this->insertModeratedMembership(
-			id: 3,
-			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+			membershipId: 3,
+			creationTime: $this->clock->now()->sub( new \DateInterval( 'P1Y' ) )
 		);
 		// create older moderated membership that got already exported and scrubbed (status, ...)
 		$this->conn->insert(
 			'request',
 			$this->newScrubbedMembershipRecord(
 				id: 4,
-				creationDate: $this->now->sub( new \DateInterval( 'P1Y' ) )
+				creationDate: $this->clock->now()->sub( new \DateInterval( 'P1Y' ) )
 			)
 		);
 		$this->assertMembershipIsAnonymized( 4 );
-		// expect report to contain 1
 		$this->assertSame( 1, $this->monitor->countOldAbandonedModeratedMembershipApplications() );
 	}
 
 	public function testCountOldAbandonedModeratedMembershipApplications_OnlyIncludesModeratedEntries(): void {
-		// TODO
 		// create normal older membership
 		$this->insertNonModeratedMembership(
 			id: 5,
-			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+			creationTime: $this->clock->now()->sub( new \DateInterval( 'P1Y' ) )
 		);
 		// create moderated older membership
 		$this->insertModeratedMembership(
-			id: 6,
-			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
+			membershipId: 6,
+			creationTime: $this->clock->now()->sub( new \DateInterval( 'P1Y' ) )
 		);
-		// expect report to contain 1
 		$this->assertSame( 1, $this->monitor->countOldAbandonedModeratedMembershipApplications() );
 	}
 
 	private function givenThrowingDatabaseConnection(): Connection {
 		$queryBuilderStub = $this->createStub( QueryBuilder::class );
-		$queryBuilderStub->method( 'executeStatement' )
+		$queryBuilderStub->method( 'executeQuery' )
 			->willThrowException( new \RuntimeException( 'Database Exception, thrown by test double' ) );
 
 		return $this->createConfiguredStub(
@@ -98,46 +91,33 @@ class DoctrineMembershipAnonymizationMonitorTest extends TestCase {
 		);
 	}
 
-	private function insertMembership( int $id = self::MEMBERSHIP_ID, ?\DateTime $creationDate = null ): void {
-		$this->conn->insert( 'request', $this->newMembershipRecord( $id, $creationDate ) );
-	}
+	private function insertModeratedMembership( int $membershipId, \DateTimeImmutable $creationTime ): void {
+		$membership = $this->newMembershipRecord( $membershipId, $creationTime );
 
-	private function insertDeletedMembership( int $id ): void {
-		$membership = $this->newMembershipRecord( $id );
-		$membership['status'] = MembershipApplication::STATUS_CANCELED;
-
-		$this->conn->insert( 'request', $membership );
-	}
-
-	private function insertModeratedMembership( int $id, \DateTime $creationTime ): void {
-		$membership = $this->newMembershipRecord( $id );
 		$membership['status'] = MembershipApplication::STATUS_MODERATION;
-		$membership['timestamp'] = $creationTime->format( 'Y-m-d H:i:s' );
 
 		$this->conn->insert( 'request', $membership );
+
+		$this->conn->executeStatement(
+			sql: 'INSERT INTO memberships_moderation_reasons (membership_id, moderation_reason_id) VALUES ( :membership_id, 1 );',
+			params: [ 'membership_id' => $membershipId ]
+		);
 	}
 
-	private function insertNonModeratedMembership( int $id, \DateTime $creationTime ): void {
-		$membership = $this->newMembershipRecord( $id );
+	private function insertNonModeratedMembership( int $id, \DateTimeImmutable $creationTime ): void {
+		$membership = $this->newMembershipRecord( $id, $creationTime );
 		$membership['status'] = MembershipApplication::STATUS_CONFIRMED;
 		$membership['timestamp'] = $creationTime->format( 'Y-m-d H:i:s' );
 
 		$this->conn->insert( 'request', $membership );
 	}
 
-	private function insertExportedMembership( int $id, \DateTime $exportTime ): void {
-		$membership = $this->newMembershipRecord( $id );
-		$membership['export'] = $exportTime->format( 'Y-m-d H:i:s' );
-		$this->conn->insert( 'request', $membership );
-	}
-
 	/**
-	 * @param int $id
 	 * @return array<string,string|int>
 	 */
-	private function newMembershipRecord( int $id, ?\DateTime $creationDate = null ): array {
-		$nowString = $this->now->format( 'Y-m-d H:i:s' );
-		$creationString = $creationDate ? $creationDate->format( 'Y-m-d H:i:s' ) : $this->now->sub( new \DateInterval( 'P1D' ) )->format( 'Y-m-d H:i:s' );
+	private function newMembershipRecord( int $id, ?\DateTimeImmutable $creationDate = null ): array {
+		$nowString = $this->clock->now()->format( 'Y-m-d H:i:s' );
+		$creationString = $creationDate ? $creationDate->format( 'Y-m-d H:i:s' ) : $this->clock->now()->sub( new \DateInterval( 'P1D' ) )->format( 'Y-m-d H:i:s' );
 		return [
 			'id' => $id,
 			'email' => 'ceo@ecorp.biz',
@@ -160,9 +140,12 @@ class DoctrineMembershipAnonymizationMonitorTest extends TestCase {
 		];
 	}
 
-	private function newScrubbedMembershipRecord( int $id, ?\DateTime $creationDate = null ): array {
-		$nowString = $this->now->format( 'Y-m-d H:i:s' );
-		$creationString = $creationDate ? $creationDate->format( 'Y-m-d H:i:s' ) : $this->now->sub( new \DateInterval( 'P1D' ) )->format( 'Y-m-d H:i:s' );
+	/**
+	 * @return array<string,string|int|null>
+	 */
+	private function newScrubbedMembershipRecord( int $id, ?\DateTimeImmutable $creationDate = null ): array {
+		$nowString = $this->clock->now()->format( 'Y-m-d H:i:s' );
+		$creationString = $creationDate ? $creationDate->format( 'Y-m-d H:i:s' ) : $this->clock->now()->sub( new \DateInterval( 'P1D' ) )->format( 'Y-m-d H:i:s' );
 		return [
 			'id' => $id,
 			'email' => '',
@@ -176,8 +159,8 @@ class DoctrineMembershipAnonymizationMonitorTest extends TestCase {
 			'plz' => '',
 			'ort' => '',
 			'dob' => null,
-			'iban' => 'DE02120300000000202051',
-			'bic' => 'BYLADEM1001',
+			'iban' => '',
+			'bic' => '',
 			'status' => MembershipApplication::STATUS_NEUTRAL,
 			'backup' => $nowString,
 			'timestamp' => $creationString,
@@ -207,20 +190,5 @@ class DoctrineMembershipAnonymizationMonitorTest extends TestCase {
 			'dob' => null,
 			'is_scrubbed' => 1
 		], $row );
-	}
-
-	/**
-	 * @param array<string,scalar> $expectedMembership
-	 * @return void
-	 * @throws \Doctrine\DBAL\Exception
-	 */
-	private function assertMembershipIsUnAnonymized( array $expectedMembership ): void {
-		unset( $expectedMembership['backup'] );
-		$result = $this->conn->executeQuery(
-			'SELECT id, anrede, firma, titel, name, vorname, nachname, strasse, plz, ort, email, iban, bic, dob, status, timestamp, is_scrubbed FROM request WHERE id = :id',
-			[ 'id' => $expectedMembership['id'] ]
-		);
-		$row = $result->fetchAssociative();
-		$this->assertEquals( $expectedMembership, $row );
 	}
 }

--- a/tests/Integration/DataAccess/DoctrineMembershipAnonymizationMonitorTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipAnonymizationMonitorTest.php
@@ -59,9 +59,12 @@ class DoctrineMembershipAnonymizationMonitorTest extends TestCase {
 			creationTime: $this->now->sub( new \DateInterval( 'P1Y' ) )
 		);
 		// create older moderated membership that got already exported and scrubbed (status, ...)
-		$this->newScrubbedMembershipRecord(
-			id: 4,
-			creationDate: $this->now->sub( new \DateInterval( 'P1Y' ) )
+		$this->conn->insert(
+			'request',
+			$this->newScrubbedMembershipRecord(
+				id: 4,
+				creationDate: $this->now->sub( new \DateInterval( 'P1Y' ) )
+			)
 		);
 		$this->assertMembershipIsAnonymized( 4 );
 		// expect report to contain 1


### PR DESCRIPTION
- we want to track whether old memberships that are still in moderation still linger in the database (we want to scrub them)

This PR introduces a new class "~AnonymizationMonitor" that does mere SELECTs of the database and counts entries that contain potential anonymization mistakes.

- [x] add tests for the monitoring methods

- belongs to https://github.com/wmde/fundraising-backend/pull/1226