### PR TITLE
Anonymise Memberships after a grace period

### DIFF
--- a/config/DoctrineClassMapping/WMDE.Fundraising.MembershipContext.DataAccess.DoctrineEntities.MembershipApplication.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.MembershipContext.DataAccess.DoctrineEntities.MembershipApplication.dcm.xml
@@ -19,7 +19,7 @@
       </options>
     </field>
     <field name="donationId" type="integer" column="donation_id" nullable="true"/>
-    <field name="creationTime" type="datetime" column="timestamp" nullable="false"/>
+    <field name="creationTime" type="datetime_immutable" column="timestamp" nullable="false"/>
     <field name="applicantSalutation" type="string" column="anrede" length="16" nullable="true"/>
     <field name="company" type="string" column="firma" length="100" nullable="true"/>
     <field name="applicantTitle" type="string" column="titel" length="16" nullable="true"/>

--- a/src/DataAccess/DoctrineEntities/MembershipApplication.php
+++ b/src/DataAccess/DoctrineEntities/MembershipApplication.php
@@ -36,7 +36,7 @@ class MembershipApplication {
 	// @phpstan-ignore-next-line
 	private ?int $donationId = null;
 
-	private ?DateTime $creationTime = null;
+	private \DateTimeImmutable $creationTime;
 
 	private ?string $applicantSalutation = null;
 
@@ -151,10 +151,10 @@ class MembershipApplication {
 	 */
 	private Collection $moderationReasons;
 
-	public function __construct() {
+	public function __construct( \DateTimeImmutable $creationTime ) {
 		$this->incentives = new ArrayCollection();
 		$this->moderationReasons = new ArrayCollection();
-		$this->creationTime = new DateTime();
+		$this->creationTime = $creationTime;
 	}
 
 	public function getId(): ?int {
@@ -165,13 +165,13 @@ class MembershipApplication {
 		$this->id = $id;
 	}
 
-	public function setCreationTime( ?DateTime $creationTime ): self {
+	public function setCreationTime( \DateTimeImmutable $creationTime ): self {
 		$this->creationTime = $creationTime;
 
 		return $this;
 	}
 
-	public function getCreationTime(): ?DateTime {
+	public function getCreationTime(): \DateTimeImmutable {
 		return $this->creationTime;
 	}
 

--- a/src/DataAccess/DoctrineMembershipAnonymizer.php
+++ b/src/DataAccess/DoctrineMembershipAnonymizer.php
@@ -4,7 +4,9 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\MembershipContext\DataAccess;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManager;
+use WMDE\Clock\Clock;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\MembershipApplication;
 use WMDE\Fundraising\MembershipContext\DataAccess\LegacyConverters\LegacyToDomainConverter;
 use WMDE\Fundraising\MembershipContext\Domain\AnonymizationException;
@@ -19,11 +21,15 @@ class DoctrineMembershipAnonymizer implements MembershipAnonymizer {
 	public function __construct(
 		private readonly MembershipRepository $membershipRepository,
 		private readonly EntityManager $entityManager,
-		private readonly PaymentAnonymizer $paymentAnonymizer
+		private readonly PaymentAnonymizer $paymentAnonymizer,
+		private readonly Clock $clock,
+		private readonly \DateInterval $gracePeriod
 	) {
 	}
 
 	public function anonymizeAll(): int {
+		$cutoffDate = $this->clock->now()->sub( $this->gracePeriod );
+
 		$queryBuilder = $this->entityManager->createQueryBuilder();
 		$queryBuilder->select( 'm' )
 			->from( MembershipApplication::class, 'm' )
@@ -33,8 +39,10 @@ class DoctrineMembershipAnonymizer implements MembershipAnonymizer {
 				$queryBuilder->expr()->in( 'm.status', [
 					strval( MembershipApplication::STATUS_CANCELED ),
 					strval( MembershipApplication::STATUS_CANCELLED_MODERATION )
-				] )
-			) );
+				] ),
+				$queryBuilder->expr()->lte( 'm.creationTime', ':cutoffDate' )
+			) )
+			->setParameter( 'cutoffDate', $cutoffDate, Types::DATETIME_IMMUTABLE );
 
 		try {
 			/** @var iterable<MembershipApplication> $memberships */
@@ -45,7 +53,7 @@ class DoctrineMembershipAnonymizer implements MembershipAnonymizer {
 
 			foreach ( $memberships as $doctrineMembership ) {
 				$membership = $converter->createFromLegacyObject( $doctrineMembership );
-				$membership->scrubPersonalData();
+				$membership->scrubPersonalData( $cutoffDate );
 				$this->membershipRepository->storeApplication( $membership );
 				$paymentIds[] = $membership->getPaymentId();
 				$count++;
@@ -65,6 +73,8 @@ class DoctrineMembershipAnonymizer implements MembershipAnonymizer {
 	}
 
 	public function anonymizeWithIds( int ...$membershipIds ): void {
+		$cutoffDate = $this->clock->now()->sub( $this->gracePeriod );
+
 		$counter = 0;
 		$paymentIds = [];
 		foreach ( $membershipIds as $id ) {
@@ -75,7 +85,7 @@ class DoctrineMembershipAnonymizer implements MembershipAnonymizer {
 			}
 
 			try {
-				$membership->scrubPersonalData();
+				$membership->scrubPersonalData( $cutoffDate );
 				$this->membershipRepository->storeApplication( $membership );
 				$paymentIds[] = $membership->getPaymentId();
 

--- a/src/DataAccess/DoctrineMembershipRepository.php
+++ b/src/DataAccess/DoctrineMembershipRepository.php
@@ -34,7 +34,7 @@ class DoctrineMembershipRepository implements MembershipRepository {
 			...$application->getModerationReasons()
 		);
 
-		$doctrineApplication = $this->table->getApplicationOrNullById( $application->getId() ) ?? new DoctrineApplication();
+		$doctrineApplication = $this->table->getApplicationOrNullById( $application->getId() ) ?? new DoctrineApplication( $application->getCreatedOn() );
 		$this->updateDoctrineApplication( $doctrineApplication, $application, $existingModerationReasons );
 		$this->table->persistApplication( $doctrineApplication );
 	}

--- a/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
+++ b/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
@@ -26,7 +26,8 @@ class LegacyToDomainConverter {
 				$doctrineApplication->getApplicantDateOfBirth()
 			),
 			$doctrineApplication->getPaymentId(),
-			$doctrineApplication->getDonationReceipt()
+			$doctrineApplication->getDonationReceipt(),
+			$doctrineApplication->getCreationTime()
 		);
 
 		if ( !$doctrineApplication->getModerationReasons()->isEmpty() ) {

--- a/src/Domain/Model/MembershipApplication.php
+++ b/src/Domain/Model/MembershipApplication.php
@@ -31,7 +31,8 @@ class MembershipApplication {
 		private readonly string $type,
 		private Applicant $applicant,
 		private readonly int $paymentId,
-		private readonly ?bool $donationReceipt
+		private readonly ?bool $donationReceipt,
+		private readonly \DateTimeImmutable $createdOn
 	) {
 		$this->moderationReasons = [];
 	}
@@ -61,6 +62,10 @@ class MembershipApplication {
 
 	public function getDonationReceipt(): ?bool {
 		return $this->donationReceipt;
+	}
+
+	public function getCreatedOn(): \DateTimeImmutable {
+		return $this->createdOn;
 	}
 
 	/**
@@ -170,8 +175,8 @@ class MembershipApplication {
 		return $this->scrubbed;
 	}
 
-	public function scrubPersonalData(): void {
-		if ( !$this->canBeScrubbed() ) {
+	public function scrubPersonalData( \DateTimeImmutable $cutOffDate ): void {
+		if ( !$this->canBeScrubbed( $cutOffDate ) ) {
 			throw new \DomainException(
 				sprintf(
 					"You can only anonymise exported or cancelled membership applications. (ID: %s, Exported: %s, Cancelled: %s)",
@@ -192,12 +197,16 @@ class MembershipApplication {
 		$this->setScrubbed();
 	}
 
-	private function canBeScrubbed(): bool {
+	private function canBeScrubbed( \DateTimeImmutable $cutOffDate ): bool {
 		if ( $this->isExported() ) {
 			return true;
 		}
 
 		if ( $this->isCancelled() ) {
+			return true;
+		}
+
+		if ( $this->createdOn <= $cutOffDate ) {
 			return true;
 		}
 

--- a/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
+++ b/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
@@ -27,7 +27,8 @@ class MembershipApplicationBuilder {
 			$request->membershipType,
 			$this->newApplicant( $request ),
 			$paymentId,
-			$request->optsIntoDonationReceipt
+			$request->optsIntoDonationReceipt,
+			new \DateTimeImmutable()
 		);
 		$this->addIncentives( $application, $request );
 		return $application;

--- a/tests/Fixtures/ValidMembershipApplication.php
+++ b/tests/Fixtures/ValidMembershipApplication.php
@@ -74,7 +74,8 @@ class ValidMembershipApplication {
 			self::MEMBERSHIP_TYPE,
 			$self->newApplicant( $self->newPersonApplicantName() ),
 			self::PAYMENT_ID,
-			self::OPTS_INTO_DONATION_RECEIPT
+			self::OPTS_INTO_DONATION_RECEIPT,
+			new \DateTimeImmutable()
 		);
 	}
 
@@ -85,7 +86,8 @@ class ValidMembershipApplication {
 			self::MEMBERSHIP_TYPE,
 			$self->newCompanyApplicant( $self->newCompanyApplicantName() ),
 			self::PAYMENT_ID,
-			self::OPTS_INTO_DONATION_RECEIPT
+			self::OPTS_INTO_DONATION_RECEIPT,
+			new \DateTimeImmutable()
 		);
 	}
 
@@ -96,7 +98,8 @@ class ValidMembershipApplication {
 			self::MEMBERSHIP_TYPE,
 			$self->newApplicant( $self->newPersonApplicantName() ),
 			self::PAYMENT_ID,
-			self::OPTS_INTO_DONATION_RECEIPT
+			self::OPTS_INTO_DONATION_RECEIPT,
+			new \DateTimeImmutable()
 		);
 	}
 
@@ -126,7 +129,8 @@ class ValidMembershipApplication {
 			self::MEMBERSHIP_TYPE,
 			$self->newApplicantWithEmailAddress( $self->newPersonApplicantName(), $emailAddress ),
 			self::PAYMENT_ID,
-			self::OPTS_INTO_DONATION_RECEIPT
+			self::OPTS_INTO_DONATION_RECEIPT,
+			new \DateTimeImmutable()
 		);
 	}
 
@@ -176,7 +180,7 @@ class ValidMembershipApplication {
 	}
 
 	private static function createDoctrineApplicationWithoutApplicantName( int $id = self::DEFAULT_ID ): DoctrineMembershipApplication {
-		$application = new DoctrineMembershipApplication();
+		$application = new DoctrineMembershipApplication( new \DateTimeImmutable() );
 
 		$application->setId( $id );
 		$application->setStatus( DoctrineMembershipApplication::STATUS_NEUTRAL );
@@ -217,7 +221,7 @@ class ValidMembershipApplication {
 		return $application;
 	}
 
-	public static function newBackedUpButUnexportedDoctrineEntity( int $id = self::DEFAULT_ID, ?DateTime $backupTime = null ): DoctrineMembershipApplication {
+	public static function newBackedUpButUnexportedDoctrineEntity( int $id = self::DEFAULT_ID, ?DateTime $backupTime = null, ?\DateTimeImmutable $createdOn = null ): DoctrineMembershipApplication {
 		$application = self::newDoctrineEntity( $id );
 		$application->setBackup( $backupTime ?? new DateTime() );
 		return $application;

--- a/tests/Integration/DataAccess/DoctrineMembershipAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipAnonymizerTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use WMDE\Clock\Clock;
+use WMDE\Clock\StubClock;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineEntities\MembershipApplication;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineMembershipAnonymizer;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineMembershipRepository;
@@ -42,11 +44,18 @@ class DoctrineMembershipAnonymizerTest extends TestCase {
 		$this->defaultExportTime = \DateTime::createFromImmutable( $this->now->sub( new \DateInterval( 'PT1H' ) ) );
 	}
 
-	private function newDoctrineMembershipAnonymizer( ?DoctrineMembershipRepository $repository = null, ?PaymentAnonymizer $paymentAnonymizer = null ): DoctrineMembershipAnonymizer {
+	private function newDoctrineMembershipAnonymizer(
+		?DoctrineMembershipRepository $repository = null,
+		?PaymentAnonymizer $paymentAnonymizer = null,
+		?Clock $clock = null,
+		?\DateInterval $gracePeriod = null
+	): DoctrineMembershipAnonymizer {
 		return new DoctrineMembershipAnonymizer(
 			$repository ?? new DoctrineMembershipRepository( $this->entityManager, $this->makeGetPaymentUseCaseStub(), new ModerationReasonRepository( $this->entityManager ) ),
 			$this->entityManager,
-			$paymentAnonymizer ?? new FakePaymentAnonymizer()
+			$paymentAnonymizer ?? new FakePaymentAnonymizer(),
+				$clock ?? new StubClock( new \DateTimeImmutable() ),
+			$gracePeriod ?? new \DateInterval( 'P1D' )
 		);
 	}
 
@@ -99,7 +108,8 @@ class DoctrineMembershipAnonymizerTest extends TestCase {
 
 	public function testAnonymizeWithIdsThrowsExceptionWhenEntryIsUnexportedAndInGracePeriod(): void {
 		$this->insertMembership( self::MEMBERSHIP_ID );
-		$anonymizer = $this->newDoctrineMembershipAnonymizer();
+		// Add a very large grace period
+		$anonymizer = $this->newDoctrineMembershipAnonymizer( gracePeriod: new \DateInterval( 'P1Y' ) );
 
 		$this->expectException( AnonymizationException::class );
 
@@ -122,11 +132,29 @@ class DoctrineMembershipAnonymizerTest extends TestCase {
 		$membership2['status'] = MembershipApplication::STATUS_CANCELLED_MODERATION;
 		$this->conn->insert( 'request', $membership1 );
 		$this->conn->insert( 'request', $membership2 );
-		$anonymizer = $this->newDoctrineMembershipAnonymizer();
+		$anonymizer = $this->newDoctrineMembershipAnonymizer( gracePeriod: new \DateInterval( 'P1Y' ) );
 
 		$anonymizer->anonymizeAll();
 
 		$this->assertMembershipIsUnAnonymized( $membership1 );
+		$this->assertMembershipIsAnonymized( self::ANOTHER_MEMBERSHIP_ID );
+	}
+
+	public function testAnonymizeAllRemovesAllOldMemberships(): void {
+		$membership1 = $this->newMembershipRecord( self::MEMBERSHIP_ID );
+		$membership1['status'] = MembershipApplication::STATUS_MODERATION;
+		$membership2 = $this->newMembershipRecord( self::ANOTHER_MEMBERSHIP_ID );
+		$membership2['status'] = MembershipApplication::STATUS_CANCELLED_MODERATION;
+		$this->conn->insert( 'request', $membership1 );
+		$this->conn->insert( 'request', $membership2 );
+		$anonymizer = $this->newDoctrineMembershipAnonymizer(
+			clock: new StubClock( ( new \DateTimeImmutable() )->add( new \DateInterval( 'P1M' ) ) ),
+			gracePeriod: new \DateInterval( 'P1M' )
+		);
+
+		$anonymizer->anonymizeAll();
+
+		$this->assertMembershipIsAnonymized( self::MEMBERSHIP_ID );
 		$this->assertMembershipIsAnonymized( self::ANOTHER_MEMBERSHIP_ID );
 	}
 

--- a/tests/Integration/DataAccess/DoctrineMembershipApplicationAuthorizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipApplicationAuthorizerTest.php
@@ -133,7 +133,7 @@ class DoctrineMembershipApplicationAuthorizerTest extends TestCase {
 	}
 
 	private function givenMembershipApplication(): MembershipApplication {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setId( self::APPLICATION_ID );
 		$application->setPaymentId( self::DUMMY_PAYMENT_ID );
 		$application->modifyDataObject( static function ( MembershipApplicationData $data ): void {
@@ -153,7 +153,7 @@ class DoctrineMembershipApplicationAuthorizerTest extends TestCase {
 	}
 
 	private function storeMembershipApplication(): MembershipApplication {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setId( self::APPLICATION_ID );
 		$application->setPaymentId( self::DUMMY_PAYMENT_ID );
 		$this->storeApplication( $application );

--- a/tests/Integration/DataAccess/DoctrineMembershipApplicationEventLoggerTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipApplicationEventLoggerTest.php
@@ -46,7 +46,7 @@ class DoctrineMembershipApplicationEventLoggerTest extends TestCase {
 	public function testWhenPersistFails_domainExceptionIsThrown(): void {
 		$entityManager = $this->createConfiguredStub(
 			EntityManager::class,
-			[ 'find' => new MembershipApplication() ]
+			[ 'find' => new MembershipApplication( new \DateTimeImmutable() ) ]
 		);
 
 		$entityManager->method( 'persist' )
@@ -60,7 +60,7 @@ class DoctrineMembershipApplicationEventLoggerTest extends TestCase {
 	}
 
 	public function testGivenMessageAndNoLogExists_createsLog(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setId( self::MEMBERSHIP_APPLICATION_ID );
 		$application->setPaymentId( self::DUMMY_PAYMENT_ID );
 		$this->entityManager->persist( $application );
@@ -78,7 +78,7 @@ class DoctrineMembershipApplicationEventLoggerTest extends TestCase {
 	}
 
 	public function testGivenMessageAndLogExists_addsRow(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setId( self::MEMBERSHIP_APPLICATION_ID );
 		$application->setPaymentId( self::DUMMY_PAYMENT_ID );
 		$application->encodeAndSetData( [ 'log' => [ '2021-01-01 0:00:00' => 'We call her the log lady' ] ] );

--- a/tests/Integration/DataAccess/DoctrineMembershipRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipRepositoryTest.php
@@ -117,13 +117,14 @@ class DoctrineMembershipRepositoryTest extends TestCase {
 	}
 
 	public function testGetMembershipApplicationById_WhenMembershipApplicationInDatabase_itIsReturnedAsMatchingDomainEntity(): void {
-		$this->storeDoctrineApplication( ValidMembershipApplication::newDoctrineEntity() );
+		$application = ValidMembershipApplication::newDomainEntity( self::MEMBERSHIP_APPLICATION_ID );
 
-		$expected = ValidMembershipApplication::newDomainEntity( self::MEMBERSHIP_APPLICATION_ID );
+		$repository = $this->givenApplicationRepository();
+		$repository->storeApplication( $application );
 
 		$this->assertEquals(
-			$expected,
-			$this->givenApplicationRepository()->getMembershipApplicationById( self::MEMBERSHIP_APPLICATION_ID )
+			$application,
+			$repository->getMembershipApplicationById( self::MEMBERSHIP_APPLICATION_ID )
 		);
 	}
 
@@ -139,25 +140,16 @@ class DoctrineMembershipRepositoryTest extends TestCase {
 	}
 
 	public function testGetMembershipApplicationById_ReadingAnonymizedApplication_itIsReturnedAsMatchingDomainEntity(): void {
-		$this->storeDoctrineApplication( ValidMembershipApplication::newBackedUpButUnexportedDoctrineEntity() );
-
 		$expected = ValidMembershipApplication::newDomainEntity( self::MEMBERSHIP_APPLICATION_ID );
 		$expected->setBackup();
+
+		$doctrineApplication = ValidMembershipApplication::newBackedUpButUnexportedDoctrineEntity();
+		$doctrineApplication->setCreationTime( $expected->getCreatedOn() );
+		$this->storeDoctrineApplication( $doctrineApplication );
 
 		$this->assertEquals(
 			$expected,
 			$this->givenApplicationRepository()->getMembershipApplicationById( self::MEMBERSHIP_APPLICATION_ID )
-		);
-	}
-
-	public function testGetUnScrubbedAndUnexportedMembershipApplicationById_WhenMembershipApplicationInDatabase_itIsReturnedAsMatchingDomainEntity(): void {
-		$this->storeDoctrineApplication( ValidMembershipApplication::newDoctrineEntity() );
-
-		$expected = ValidMembershipApplication::newDomainEntity( self::MEMBERSHIP_APPLICATION_ID );
-
-		$this->assertEquals(
-			$expected,
-			$this->givenApplicationRepository()->getUnexportedAndUnscrubbedMembershipApplicationById( self::MEMBERSHIP_APPLICATION_ID )
 		);
 	}
 

--- a/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -96,7 +96,7 @@ class SerializedDataHandlingTest extends TestCase {
 	 * @return void
 	 */
 	private function storeMembershipApplication( EntityManager $entityManager, array $data ): void {
-		$membershipAppl = new MembershipApplication();
+		$membershipAppl = new MembershipApplication( new \DateTimeImmutable() );
 
 		$membershipAppl->setId( self::MEMBERSHIP_APPLICATION_ID );
 		$membershipAppl->setPaymentId( 1 );

--- a/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -144,11 +144,9 @@ class ApplyForMembershipUseCaseTest extends TestCase {
 
 		$result = $this->makeUseCase( repository: $repository )->applyForMembership( $this->newValidRequest() );
 
-		$expectedApplication = ValidMembershipApplication::newDomainEntity( self::MEMBERSHIP_APPLICATION_ID );
-		$expectedApplication->confirm();
-		$application = $repository->getUnexportedAndUnscrubbedMembershipApplicationById( $expectedApplication->getId() );
+		$application = $repository->getUnexportedAndUnscrubbedMembershipApplicationById( self::MEMBERSHIP_APPLICATION_ID );
 		$this->assertNotNull( $application );
-		$this->assertEquals( $expectedApplication, $application );
+		$this->assertEquals( $result->getMembershipApplication(), $application );
 	}
 
 	public function testGivenValidRequest_confirmationEmailIsSent(): void {

--- a/tests/Unit/DoctrineEntities/MembershipApplicationTest.php
+++ b/tests/Unit/DoctrineEntities/MembershipApplicationTest.php
@@ -14,14 +14,14 @@ use WMDE\Fundraising\MembershipContext\DataAccess\MembershipApplicationData;
 class MembershipApplicationTest extends TestCase {
 
 	public function testWhenSettingIdToAnInteger_getIdReturnsIt(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setId( 1337 );
 
 		$this->assertSame( 1337, $application->getId() );
 	}
 
 	public function testWhenSettingIdToNull_getIdReturnsNull(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setId( 1337 );
 		$application->setId( null );
 
@@ -29,13 +29,13 @@ class MembershipApplicationTest extends TestCase {
 	}
 
 	public function testWhenIdIsNotSet_getIdReturnsNull(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 
 		$this->assertNull( $application->getId() );
 	}
 
 	public function testGivenNoData_getDataObjectReturnsObjectWithNullValues(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 
 		$this->assertNull( $application->getDataObject()->getAccessToken() );
 		$this->assertNull( $application->getDataObject()->getUpdateToken() );
@@ -48,7 +48,7 @@ class MembershipApplicationTest extends TestCase {
 		$data->setUpdateToken( 'bar' );
 		$data->setPreservedStatus( 1337 );
 
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setDataObject( $data );
 
 		$this->assertSame(
@@ -62,7 +62,7 @@ class MembershipApplicationTest extends TestCase {
 	}
 
 	public function testWhenProvidingNullData_setObjectDoesNotSetFields(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setDataObject( new MembershipApplicationData() );
 
 		$this->assertSame(
@@ -72,7 +72,7 @@ class MembershipApplicationTest extends TestCase {
 	}
 
 	public function testWhenDataAlreadyExists_setDataObjectRetainsAndUpdatesData(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->encodeAndSetData( [
 			'nyan' => 'cat',
 			'token' => 'wee',
@@ -100,7 +100,7 @@ class MembershipApplicationTest extends TestCase {
 	 * @deprecated Remove when removing {@see MembershipApplication::modifyDataObject}
 	 */
 	public function testWhenModifyingTheDataObject_modificationsAreReflected(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->encodeAndSetData( [
 			'nyan' => 'cat',
 			'token' => 'wee',
@@ -124,20 +124,20 @@ class MembershipApplicationTest extends TestCase {
 	}
 
 	public function testGivenModerationStatus_needsModerationReturnsTrue(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setStatus( MembershipApplication::STATUS_MODERATION );
 
 		$this->assertTrue( $application->needsModeration() );
 	}
 
 	public function testGivenDefaultStatus_needsModerationReturnsFalse(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 
 		$this->assertFalse( $application->needsModeration() );
 	}
 
 	public function testGivenModerationAndCancelledStatus_needsModerationReturnsTrue(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setStatus(
 			MembershipApplication::STATUS_MODERATION + MembershipApplication::STATUS_CANCELED
 		);
@@ -146,20 +146,20 @@ class MembershipApplicationTest extends TestCase {
 	}
 
 	public function testGivenCancelledStatus_isCancelledReturnsTrue(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setStatus( MembershipApplication::STATUS_CANCELED );
 
 		$this->assertTrue( $application->isCancelled() );
 	}
 
 	public function testGivenDefaultStatus_isCancelledReturnsFalse(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 
 		$this->assertFalse( $application->isCancelled() );
 	}
 
 	public function testGivenModerationAndCancelledStatus_isCancelledReturnsTrue(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setStatus(
 			MembershipApplication::STATUS_MODERATION + MembershipApplication::STATUS_CANCELED
 		);
@@ -168,19 +168,19 @@ class MembershipApplicationTest extends TestCase {
 	}
 
 	public function testGivenDefaultStatus_isDeletedReturnsFalse(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 
 		$this->assertFalse( $application->isCancelled() );
 	}
 
 	public function testDefaultDonationReceiptValue_isNull(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 
 		$this->assertNull( $application->getDonationReceipt() );
 	}
 
 	public function testSetDonationReceiptValue_canBeRetrieved(): void {
-		$application = new MembershipApplication();
+		$application = new MembershipApplication( new \DateTimeImmutable() );
 		$application->setDonationReceipt( false );
 
 		$this->assertFalse( $application->getDonationReceipt() );

--- a/tests/Unit/Domain/Model/MembershipApplicationTest.php
+++ b/tests/Unit/Domain/Model/MembershipApplicationTest.php
@@ -125,14 +125,14 @@ class MembershipApplicationTest extends TestCase {
 
 		$this->expectException( \DomainException::class );
 
-		$application->scrubPersonalData();
+		$application->scrubPersonalData( ( new \DateTimeImmutable() )->sub( new \DateInterval( 'P1D' ) ) );
 	}
 
 	public function testScrubsPersonalData(): void {
 		$application = ValidMembershipApplication::newApplication();
 		$application->setExported();
 
-		$application->scrubPersonalData();
+		$application->scrubPersonalData( new \DateTimeImmutable() );
 
 		$this->assertSame( '', $application->getApplicant()->getName()->firstName );
 		$this->assertSame( '', $application->getApplicant()->getName()->lastName );
@@ -152,7 +152,7 @@ class MembershipApplicationTest extends TestCase {
 		$application = ValidMembershipApplication::newCompanyApplication();
 		$application->setExported();
 
-		$application->scrubPersonalData();
+		$application->scrubPersonalData( new \DateTimeImmutable() );
 
 		$this->assertSame( '', $application->getApplicant()->getName()->firstName );
 		$this->assertSame( '', $application->getApplicant()->getName()->lastName );
@@ -172,7 +172,7 @@ class MembershipApplicationTest extends TestCase {
 		$application = ValidMembershipApplication::newApplication();
 		$application->cancel();
 
-		$application->scrubPersonalData();
+		$application->scrubPersonalData( new \DateTimeImmutable() );
 
 		$this->assertTrue( $application->isScrubbed() );
 	}

--- a/tests/Unit/LegacyConverters/DomainToLegacyConverterTest.php
+++ b/tests/Unit/LegacyConverters/DomainToLegacyConverterTest.php
@@ -18,7 +18,7 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\LegacyPaymentData;
 class DomainToLegacyConverterTest extends TestCase {
 
 	public function testWhenPersistingApplicationWithModerationFlag_doctrineApplicationHasFlag(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$moderationReasons = [
 			$this->makeGenericModerationReason(),
 			new ModerationReason( ModerationIdentifier::MEMBERSHIP_FEE_TOO_HIGH )
@@ -45,7 +45,7 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function testWhenPersistingApplicationWithCancelledFlag_doctrineApplicationHasFlag(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->cancel();
 
@@ -63,7 +63,7 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function testWhenPersistingApplicationWithConfirmedFlag_doctrineApplicationHasFlag(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->confirm();
 
@@ -81,7 +81,7 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function testWhenPersistingNonConfirmedOrModeratedOrCancelledApplication_doctrineApplicationHasFlag(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 
 		$converter = new DomainToLegacyConverter();
@@ -98,7 +98,7 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function testWhenPersistingCancelledModerationApplication_doctrineApplicationHasFlags(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 		$moderationReason = $this->makeGenericModerationReason();
 		$application->markForModeration( $moderationReason );
@@ -118,7 +118,7 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function testWhenGivenPayment_setsInMembershipApplication(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 
 		$paymentData = new LegacyPaymentData( 1, 1, 'UEB', [
@@ -143,7 +143,7 @@ class DomainToLegacyConverterTest extends TestCase {
 
 	public function testGivenApplicationWithIncentives_addsThemToDomainApplication(): void {
 		$incentive = new Incentive( 'PS5 and 3080 GPU and Blue Hearts album on vinyl and Analogue Pocket' );
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->addIncentive( $incentive );
 
@@ -162,7 +162,7 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function testWhenApplicationIsScrubbed_marksDomainApplicationAsAnonymized(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->setScrubbed();
 
@@ -178,7 +178,7 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function testWhenApplicationIsNotScrubbed_domainApplicationIsNotMarkedAsAnonymized(): void {
-		$doctrineApplication = new DoctrineApplication();
+		$doctrineApplication = new DoctrineApplication( new \DateTimeImmutable() );
 		$application = ValidMembershipApplication::newDomainEntity();
 
 		$converter = new DomainToLegacyConverter();

--- a/tests/Unit/LegacyConverters/LegacyToDomainConverterTest.php
+++ b/tests/Unit/LegacyConverters/LegacyToDomainConverterTest.php
@@ -89,6 +89,15 @@ class LegacyToDomainConverterTest extends TestCase {
 		$this->assertEquals( $doctrineApplication->getApplicantTitle(), $application->getApplicant()->getName()->title );
 	}
 
+	public function testGivenDoctrineApplication_setsCreatedOnInDomain(): void {
+		$doctrineApplication = ValidMembershipApplication::newDoctrineEntity();
+
+		$converter = new LegacyToDomainConverter();
+		$application = $converter->createFromLegacyObject( $doctrineApplication );
+
+		$this->assertSame( $doctrineApplication->getCreationTime(), $application->getCreatedOn() );
+	}
+
 	public function testGivenDoctrineApplicationThatNeedsModeration_setsNeedsModerationInDomain(): void {
 		$doctrineApplication = ValidMembershipApplication::newDoctrineEntity();
 		$converter = new LegacyToDomainConverter();


### PR DESCRIPTION
Add a creation time to the MembershipApplication
domain model. Add guard clause to the canBeScrubbed
method that checks the created date.

Use that creation time when storing the application.

Make DoctrineMembershipAnonymizer check for older
applications when scrubbing.

Ticket: https://phabricator.wikimedia.org/T431116