### PR TITLE
Fix PHPUnit notice

### DIFF
--- a/tests/Integration/DataAccess/DoctrineMembershipAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineMembershipAnonymizerTest.php
@@ -96,7 +96,7 @@ class DoctrineMembershipAnonymizerTest extends TestCase {
 	}
 
 	public function testAnonymizeWithIdsTransformsDatabaseExceptions(): void {
-		$membershipRepository = $this->createMock( DoctrineMembershipRepository::class );
+		$membershipRepository = $this->createStub( DoctrineMembershipRepository::class );
 		$membershipRepository->method( 'getMembershipApplicationById' )->willReturn( ValidMembershipApplication::newApplication() );
 		$membershipRepository->method( 'storeApplication' )->willThrowException( new StoreMembershipApplicationException( 'Could not store' ) );
 		$anonymizer = $this->newDoctrineMembershipAnonymizer( repository: $membershipRepository );


### PR DESCRIPTION
A test used a mock without asserting anything on it, creating a PHPUnit notice to convert it to a stub.